### PR TITLE
Add REST API, authentication mechanisms

### DIFF
--- a/cmd/ocp/main.go
+++ b/cmd/ocp/main.go
@@ -63,7 +63,7 @@ func runSCP(cmd *cobra.Command, args []string) {
 	}
 
 	// Determine if upload or download
-	isUpload := !strings.Contains(source, "@")
+	isUpload := !strings.Contains(source, ":")
 
 	// Copy file
 	if err := scpClient.Copy(source, destination, isUpload); err != nil {

--- a/config/server.example.yaml
+++ b/config/server.example.yaml
@@ -1,7 +1,9 @@
 server:
   host: "0.0.0.0"
   port: 2222
+  api_port: 8080
   ssh_host_key: "/etc/orion-belt/ssh_host_key"
+  api_endpoint: "http://localhost:8080/api"
 
 database:
   driver: "postgres"
@@ -14,12 +16,15 @@ auth:
 recording:
   enabled: true
   storage_path: "/var/lib/orion-belt/recordings"
+  retention_days: 90
 
 plugins:
   notification:
     enabled: true
     smtp_host: "smtp.example.com"
     smtp_port: 587
+    smtp_user: "orion-belt@example.com"
+    smtp_password: "secret"
     from_email: "orion-belt@example.com"
     admin_emails:
       - "admin@example.com"

--- a/docs/API/postman_collection.json
+++ b/docs/API/postman_collection.json
@@ -1,0 +1,994 @@
+{
+	"info": {
+		"_postman_id": "orion-belt-api-collection",
+		"name": "Orion Belt PAM API",
+		"description": "Complete API collection for testing Orion Belt Privileged Access Management system",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"variable": [
+		{
+			"key": "base_url",
+			"value": "http://localhost:8080",
+			"type": "string"
+		},
+		{
+			"key": "session_token",
+			"value": "",
+			"type": "string"
+		},
+		{
+			"key": "api_key",
+			"value": "",
+			"type": "string"
+		},
+		{
+			"key": "user_id",
+			"value": "",
+			"type": "string"
+		},
+		{
+			"key": "machine_id",
+			"value": "",
+			"type": "string"
+		},
+		{
+			"key": "access_request_id",
+			"value": "",
+			"type": "string"
+		}
+	],
+	"item": [
+		{
+			"name": "1. Health & Setup",
+			"item": [
+				{
+					"name": "Health Check",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Service is healthy\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.status).to.eql(\"healthy\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/health",
+							"host": ["{{base_url}}"],
+							"path": ["health"]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "2. User Registration",
+			"item": [
+				{
+					"name": "Register Admin User (Alice)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.collectionVariables.set(\"user_id\", jsonData.user_id);",
+									"",
+									"pm.test(\"User ID received\", function () {",
+									"    pm.expect(jsonData.user_id).to.be.a('string');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"username\": \"alice\",\n  \"email\": \"alice@example.com\",\n  \"public_key\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDExample1234567890 alice@laptop\",\n  \"is_admin\": true\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/public/register/client",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "public", "register", "client"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Register Regular User (Bob)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"username\": \"bob\",\n  \"email\": \"bob@example.com\",\n  \"public_key\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDExample0987654321 bob@laptop\",\n  \"is_admin\": false\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/public/register/client",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "public", "register", "client"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Register Agent (web-server-01)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.collectionVariables.set(\"machine_id\", jsonData.machine_id);",
+									"",
+									"pm.test(\"Machine ID received\", function () {",
+									"    pm.expect(jsonData.machine_id).to.be.a('string');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"web-server-01\",\n  \"hostname\": \"192.168.1.100\",\n  \"port\": 22,\n  \"public_key\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAgentKey123456 agent@web-server-01\",\n  \"tags\": {\n    \"environment\": \"production\",\n    \"role\": \"webserver\"\n  }\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/public/register/agent",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "public", "register", "agent"]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "3. Authentication",
+			"item": [
+				{
+					"name": "Login (Get Session Token)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.collectionVariables.set(\"session_token\", jsonData.session_token);",
+									"",
+									"pm.test(\"Session token received\", function () {",
+									"    pm.expect(jsonData.session_token).to.be.a('string');",
+									"    pm.expect(jsonData.session_token.length).to.be.above(20);",
+									"});",
+									"",
+									"pm.test(\"User info correct\", function () {",
+									"    pm.expect(jsonData.user.username).to.eql(\"alice\");",
+									"    pm.expect(jsonData.user.is_admin).to.be.true;",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"username\": \"alice\"\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/public/login",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "public", "login"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Current User (with Session)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"User is alice\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.username).to.eql(\"alice\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Session-Token",
+								"value": "{{session_token}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/auth/me",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "auth", "me"]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "4. API Key Management",
+			"item": [
+				{
+					"name": "Create API Key (90 days)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.collectionVariables.set(\"api_key\", jsonData.api_key);",
+									"",
+									"pm.test(\"API key received\", function () {",
+									"    pm.expect(jsonData.api_key).to.be.a('string');",
+									"    pm.expect(jsonData.api_key.length).to.be.above(30);",
+									"});",
+									"",
+									"console.log(\"⚠️  IMPORTANT: Save this API key! It's only shown once!\");",
+									"console.log(\"API Key:\", jsonData.api_key);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-Session-Token",
+								"value": "{{session_token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Test API Key\",\n  \"expires_in\": 90\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/api-keys",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "api-keys"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List User API Keys",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Keys array exists\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.api_keys).to.be.an('array');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Session-Token",
+								"value": "{{session_token}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/api-keys",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "api-keys"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Test API Key Authentication",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"API key works\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.an('array');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/machines",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "machines"]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "5. User Management",
+			"item": [
+				{
+					"name": "List All Users",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Users array exists\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.an('array');",
+									"    pm.expect(jsonData.length).to.be.above(0);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/users",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "users"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Specific User",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/users/{{user_id}}",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "users", "{{user_id}}"]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "6. Machine Management",
+			"item": [
+				{
+					"name": "List All Machines",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Machines array exists\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.an('array');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/machines",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "machines"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Specific Machine",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Machine details exist\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.name).to.be.a('string');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/machines/{{machine_id}}",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "machines", "{{machine_id}}"]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "7. Permission Management",
+			"item": [
+				{
+					"name": "Grant Permission (SSH)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"user_id\": \"{{user_id}}\",\n  \"machine_id\": \"{{machine_id}}\",\n  \"access_type\": \"ssh\"\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/permissions",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "permissions"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List User Permissions",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/permissions/user/{{user_id}}",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "permissions", "user", "{{user_id}}"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List Machine Permissions",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/permissions/machine/{{machine_id}}",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "permissions", "machine", "{{machine_id}}"]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "8. Access Requests",
+			"item": [
+				{
+					"name": "Create Access Request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.collectionVariables.set(\"access_request_id\", jsonData.id);",
+									"",
+									"pm.test(\"Request ID received\", function () {",
+									"    pm.expect(jsonData.id).to.be.a('string');",
+									"    pm.expect(jsonData.status).to.eql(\"pending\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"machine_id\": \"{{machine_id}}\",\n  \"reason\": \"Emergency database maintenance\",\n  \"duration\": 3600\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/access-requests",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "access-requests"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List Pending Access Requests",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Requests array exists\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.an('array');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/access-requests/pending",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "access-requests", "pending"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Approve Access Request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Request approved\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.status).to.eql(\"approved\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"reviewer_id\": \"{{user_id}}\"\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/access-requests/{{access_request_id}}/approve",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "access-requests", "{{access_request_id}}", "approve"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Reject Access Request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"reviewer_id\": \"{{user_id}}\"\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/access-requests/{{access_request_id}}/reject",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "access-requests", "{{access_request_id}}", "reject"]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "9. Session Management",
+			"item": [
+				{
+					"name": "List Active Sessions",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/sessions/active",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "sessions", "active"]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List All Sessions",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/sessions",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "sessions"]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "10. Audit Logs",
+			"item": [
+				{
+					"name": "List Audit Logs",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Logs array exists\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.an('array');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-API-Key",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/audit-logs",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "audit-logs"]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "11. Logout",
+			"item": [
+				{
+					"name": "Logout (Destroy Session)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Logged out successfully\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.message).to.include(\"logged out\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "X-Session-Token",
+								"value": "{{session_token}}"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/api/v1/logout",
+							"host": ["{{base_url}}"],
+							"path": ["api", "v1", "logout"]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	]
+}

--- a/docs/API/postman_env.json
+++ b/docs/API/postman_env.json
@@ -1,0 +1,43 @@
+{
+	"id": "orion-belt-local-env",
+	"name": "Orion Belt - Local",
+	"values": [
+		{
+			"key": "base_url",
+			"value": "http://localhost:8080",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "session_token",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "api_key",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "user_id",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "machine_id",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "access_request_id",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment"
+}

--- a/pkg/api/auth_endpoint.go
+++ b/pkg/api/auth_endpoint.go
@@ -1,0 +1,244 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CreateAPIKeyRequest represents a request to create an API key
+type CreateAPIKeyRequest struct {
+	Name      string `json:"name" binding:"required"`
+	ExpiresIn *int   `json:"expires_in"` // Duration in days (optional)
+}
+
+// CreateAPIKeyResponse represents the response when creating an API key
+type CreateAPIKeyResponse struct {
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	APIKey    string     `json:"api_key"`
+	KeyPrefix string     `json:"key_prefix"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+// createAPIKey handles API key creation
+func (s *APIServer) createAPIKey(c *gin.Context) {
+	var req CreateAPIKeyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Get authenticated user
+	userID, _ := c.Get("user_id")
+	ctx := c.Request.Context()
+
+	// Calculate expiration
+	var expiresAt *time.Time
+	if req.ExpiresIn != nil {
+		expiry := time.Now().AddDate(0, 0, *req.ExpiresIn)
+		expiresAt = &expiry
+	}
+
+	// Generate API key
+	apiKey, rawKey, err := s.authService.GenerateAPIKey(ctx, userID.(string), req.Name, expiresAt)
+	if err != nil {
+		s.logger.Error("Failed to create API key: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create API key"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, CreateAPIKeyResponse{
+		ID:        apiKey.ID,
+		Name:      apiKey.Name,
+		APIKey:    rawKey,
+		KeyPrefix: apiKey.KeyPrefix,
+		ExpiresAt: apiKey.ExpiresAt,
+		CreatedAt: apiKey.CreatedAt,
+	})
+}
+
+// listAPIKeys lists all API keys for the authenticated user
+func (s *APIServer) listAPIKeys(c *gin.Context) {
+	userID, _ := c.Get("user_id")
+	ctx := c.Request.Context()
+
+	keys, err := s.authService.ListUserAPIKeys(ctx, userID.(string))
+	if err != nil {
+		s.logger.Error("Failed to list API keys: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list API keys"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"api_keys": keys})
+}
+
+// revokeAPIKey revokes an API key
+func (s *APIServer) revokeAPIKey(c *gin.Context) {
+	keyID := c.Param("id")
+	userID, _ := c.Get("user_id")
+	ctx := c.Request.Context()
+
+	// TODO: implemet auth checks
+	key, err := s.store.GetAPIKey(ctx, keyID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "API key not found"})
+		return
+	}
+
+	// TODO: implemet auth checks
+	isAdmin, _ := c.Get("is_admin")
+	if key.UserID != userID.(string) && !isAdmin.(bool) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
+		return
+	}
+
+	// Revoke the key
+	if err := s.authService.RevokeAPIKey(ctx, keyID); err != nil {
+		s.logger.Error("Failed to revoke API key: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to revoke API key"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "API key revoked successfully"})
+}
+
+// deleteAPIKey permanently deletes an API key
+func (s *APIServer) deleteAPIKey(c *gin.Context) {
+	keyID := c.Param("id")
+	userID, _ := c.Get("user_id")
+	ctx := c.Request.Context()
+
+	// TODO: implemet auth checks
+	key, err := s.store.GetAPIKey(ctx, keyID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "API key not found"})
+		return
+	}
+
+	// TODO: implemet auth checks
+	isAdmin, _ := c.Get("is_admin")
+	if key.UserID != userID.(string) && !isAdmin.(bool) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
+		return
+	}
+
+	// Delete the key
+	if err := s.store.DeleteAPIKey(ctx, keyID); err != nil {
+		s.logger.Error("Failed to delete API key: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete API key"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "API key deleted successfully"})
+}
+
+// LoginRequest represents a login request
+type LoginRequest struct {
+	Username  string `json:"username" binding:"required"`
+	Password  string `json:"password"`   // TODO: implemet proper password auth
+	PublicKey string `json:"public_key"` // TODO: implemet proper key auth
+}
+
+// LoginResponse represents a login response
+type LoginResponse struct {
+	SessionToken string    `json:"session_token"`
+	ExpiresAt    time.Time `json:"expires_at"`
+	User         struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+		Email    string `json:"email"`
+		IsAdmin  bool   `json:"is_admin"`
+	} `json:"user"`
+}
+
+// login handles user login and session creation
+func (s *APIServer) login(c *gin.Context) {
+	var req LoginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	// TODO: implemet auth checks and password checks
+	user, err := s.store.GetUserByUsername(ctx, req.Username)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+		return
+	}
+
+	// Create session TTL 60m
+	session, rawToken, err := s.authService.CreateSession(
+		ctx,
+		user.ID,
+		c.ClientIP(),
+		c.Request.UserAgent(),
+		60*time.Minute,
+	)
+	if err != nil {
+		s.logger.Error("Failed to create session: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create session"})
+		return
+	}
+
+	response := LoginResponse{
+		SessionToken: rawToken,
+		ExpiresAt:    session.ExpiresAt,
+	}
+	response.User.ID = user.ID
+	response.User.Username = user.Username
+	response.User.Email = user.Email
+	response.User.IsAdmin = user.IsAdmin
+
+	c.JSON(http.StatusOK, response)
+}
+
+// logout handles user logout (session destruction)
+func (s *APIServer) logout(c *gin.Context) {
+	authMethod, _ := c.Get("auth_method")
+	if authMethod != "session" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "not logged in via session"})
+		return
+	}
+
+	sessionToken := c.GetHeader("X-Session-Token")
+	if sessionToken == "" {
+		if cookie, err := c.Cookie("session_token"); err == nil {
+			sessionToken = cookie
+		}
+	}
+
+	if sessionToken == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no session token provided"})
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	tokenHash := hashSessionToken(sessionToken)
+	session, err := s.store.GetHTTPSessionByToken(ctx, tokenHash)
+	if err == nil {
+		_ = s.authService.DestroySession(ctx, session.ID)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "logged out successfully"})
+}
+
+// getCurrentUser returns the currently authenticated user
+func (s *APIServer) getCurrentUser(c *gin.Context) {
+	// TODO: implemet auth checks
+	userID, _ := c.Get("user_id")
+	ctx := c.Request.Context()
+
+	user, err := s.store.GetUser(ctx, userID.(string))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, user)
+}

--- a/pkg/api/middelware.go
+++ b/pkg/api/middelware.go
@@ -1,39 +1,192 @@
 package api
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/zrougamed/orion-belt/pkg/common"
 )
 
+// AuthContext holds the authenticated user context
+type AuthContext struct {
+	UserID     string
+	Username   string
+	IsAdmin    bool
+	AuthMethod string // "api_key", "session", "bearer"
+}
+
+// loggingMiddleware logs all HTTP requests
 func (s *APIServer) loggingMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
 		path := c.Request.URL.Path
+		method := c.Request.Method
 
 		c.Next()
 
 		duration := time.Since(start)
-		s.logger.Info("%s %s %d %v", c.Request.Method, path, c.Writer.Status(), duration)
+		status := c.Writer.Status()
+
+		s.logger.Info("%s %s %d %v", method, path, status, duration)
 	}
 }
 
+// authMiddleware enforces authentication for protected endpoints
 func (s *APIServer) authMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// TODO: Implement proper authentication (JWT, API keys, etc.)
-		// For now, we use a simple API key or skip authentication
-		apiKey := c.GetHeader("X-API-Key")
-		if apiKey == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "missing API key"})
+		ctx := c.Request.Context()
+
+		// Try API Key authentication
+		if apiKey := c.GetHeader("X-API-Key"); apiKey != "" {
+			if user, err := s.validateAPIKey(ctx, apiKey); err == nil {
+				s.setAuthContext(c, user.ID, user.Username, user.IsAdmin, "api_key")
+				c.Next()
+				return
+			}
+		}
+
+		// Try Session Token authentication
+		sessionToken := c.GetHeader("X-Session-Token")
+		if sessionToken == "" {
+			if cookie, err := c.Cookie("session_token"); err == nil {
+				sessionToken = cookie
+			}
+		}
+		if sessionToken != "" {
+			if user, err := s.validateSession(ctx, sessionToken); err == nil {
+				s.setAuthContext(c, user.ID, user.Username, user.IsAdmin, "session")
+				c.Next()
+				return
+			}
+		}
+
+		// Try Bearer Token authentication
+		if authHeader := c.GetHeader("Authorization"); authHeader != "" {
+			if strings.HasPrefix(authHeader, "Bearer ") {
+				bearerToken := strings.TrimPrefix(authHeader, "Bearer ")
+				if user, err := s.validateBearerToken(ctx, bearerToken); err == nil {
+					s.setAuthContext(c, user.ID, user.Username, user.IsAdmin, "bearer")
+					c.Next()
+					return
+				}
+			}
+		}
+
+		// No valid authentication found
+		s.logger.Warn("Authentication failed for %s %s from %s", c.Request.Method, c.Request.URL.Path, c.ClientIP())
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "authentication required",
+		})
+		c.Abort()
+	}
+}
+
+// adminMiddleware requires the authenticated user to be an admin
+func (s *APIServer) adminMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		isAdmin, exists := c.Get("is_admin")
+		// TODO: implemet auth checks
+		if !exists || !isAdmin.(bool) {
+			userID, _ := c.Get("user_id")
+			s.logger.Warn("Admin access denied for user: %v", userID)
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "admin privileges required",
+			})
 			c.Abort()
 			return
 		}
-
-		// TODO: Validate API key against database
-		c.Set("user_id", "current-user-id")
 		c.Next()
 	}
+}
+
+// setAuthContext sets authentication context in the Gin context
+func (s *APIServer) setAuthContext(c *gin.Context, userID, username string, isAdmin bool, authMethod string) {
+	c.Set("user_id", userID)
+	c.Set("username", username)
+	c.Set("is_admin", isAdmin)
+	c.Set("auth_method", authMethod)
+	c.Set("authenticated", true)
+}
+
+// validateAPIKey validates an API key and returns the associated user
+func (s *APIServer) validateAPIKey(ctx context.Context, apiKey string) (*common.User, error) {
+	keyHash := hashAPIKey(apiKey)
+
+	key, err := s.store.GetAPIKeyByHash(ctx, keyHash)
+	if err != nil {
+		return nil, fmt.Errorf("invalid API key")
+	}
+
+	if key.RevokedAt != nil {
+		return nil, fmt.Errorf("API key has been revoked")
+	}
+
+	if key.ExpiresAt != nil && time.Now().After(*key.ExpiresAt) {
+		return nil, fmt.Errorf("API key has expired")
+	}
+
+	go func() {
+		_ = s.store.UpdateAPIKeyLastUsed(ctx, key.ID, time.Now())
+	}()
+
+	user, err := s.store.GetUser(ctx, key.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("user not found for API key")
+	}
+
+	s.logger.Debug("API key authenticated: user=%s key=%s", user.Username, key.Name)
+	return user, nil
+}
+
+// validateSession validates a session token and returns the associated user
+func (s *APIServer) validateSession(ctx context.Context, sessionToken string) (*common.User, error) {
+	tokenHash := hashSessionToken(sessionToken)
+
+	session, err := s.store.GetHTTPSessionByToken(ctx, tokenHash)
+	if err != nil {
+		return nil, fmt.Errorf("invalid session token")
+	}
+
+	if time.Now().After(session.ExpiresAt) {
+		_ = s.store.DeleteHTTPSession(ctx, session.ID)
+		return nil, fmt.Errorf("session has expired")
+	}
+
+	go func() {
+		_ = s.store.UpdateHTTPSessionLastSeen(ctx, session.ID, time.Now())
+	}()
+
+	user, err := s.store.GetUser(ctx, session.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("user not found for session")
+	}
+
+	s.logger.Debug("Session authenticated: user=%s", user.Username)
+	return user, nil
+}
+
+// validateBearerToken validates a JWT bearer token
+func (s *APIServer) validateBearerToken(ctx context.Context, token string) (*common.User, error) {
+	// TODO: implemet JWT
+	return nil, fmt.Errorf("JWT authentication not yet implemented")
+}
+
+// hashAPIKey creates a SHA256 hash of an API key
+func hashAPIKey(key string) string {
+	hash := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(hash[:])
+}
+
+// hashSessionToken creates a SHA256 hash of a session token
+func hashSessionToken(token string) string {
+	hash := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(hash[:])
 }
 
 // Start starts the API server
@@ -42,7 +195,7 @@ func (s *APIServer) Start(addr string) error {
 	return s.router.Run(addr)
 }
 
-// Router returns the Gin router (for testing)
+// Router returns the Gin router
 func (s *APIServer) Router() *gin.Engine {
 	return s.router
 }

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -19,6 +19,7 @@ type Config struct {
 type ServerConfig struct {
 	Host        string `yaml:"host"`
 	Port        int    `yaml:"port"`
+	APIPort     int    `yaml:"api_port,omitempty"`
 	SSHHostKey  string `yaml:"ssh_host_key,omitempty"`
 	APIEndpoint string `yaml:"api_endpoint,omitempty"`
 }

--- a/pkg/database/store.go
+++ b/pkg/database/store.go
@@ -53,6 +53,23 @@ type Store interface {
 	CreateAuditLog(ctx context.Context, log *common.AuditLog) error
 	ListAuditLogs(ctx context.Context, limit, offset int, filters map[string]interface{}) ([]*common.AuditLog, error)
 
+	// API Key operations
+	CreateAPIKey(ctx context.Context, key *common.APIKey) error
+	GetAPIKey(ctx context.Context, id string) (*common.APIKey, error)
+	GetAPIKeyByHash(ctx context.Context, keyHash string) (*common.APIKey, error)
+	ListUserAPIKeys(ctx context.Context, userID string) ([]*common.APIKey, error)
+	UpdateAPIKeyLastUsed(ctx context.Context, id string, lastUsedAt time.Time) error
+	RevokeAPIKey(ctx context.Context, id string) error
+	DeleteAPIKey(ctx context.Context, id string) error
+
+	// HTTP Session operations
+	CreateHTTPSession(ctx context.Context, session *common.HTTPSession) error
+	GetHTTPSession(ctx context.Context, id string) (*common.HTTPSession, error)
+	GetHTTPSessionByToken(ctx context.Context, tokenHash string) (*common.HTTPSession, error)
+	UpdateHTTPSessionLastSeen(ctx context.Context, id string, lastSeenAt time.Time) error
+	DeleteHTTPSession(ctx context.Context, id string) error
+	DeleteExpiredHTTPSessions(ctx context.Context) error
+
 	// Lifecycle
 	Connect(ctx context.Context) error
 	Close() error


### PR DESCRIPTION
This PR introduces several core enhancements to the Orion-Belt:

- REST API: Implemented a Gin-based API server with endpoints for health checks, user/machine management, and access requests.
- Authentication: Added support for both session-based (HTTP sessions) and programmatic (API keys) authentication.
- Documentation: Included a comprehensive Postman collection for the new API.
- Fixes: Updated SCP logic to correctly determine upload/download directions and refined database migrations to include API key and session tables.

Pending: 
- JWT implementation 
- CLI registration for Machines using `orion` tool 
- Password management
- Redis to manage server state i/o LRU ( aim persist state )
- implement support for SSH keys ECDSA, Ed25519, Ed448, FIDO...
- implement auth checks for the API
- notification pluggin 
- session auth request