### PR TITLE
feat: add remote user specification for SSH and SCP connections

### DIFF
--- a/cmd/ocp/main.go
+++ b/cmd/ocp/main.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	configFile string
+	username   string
 	recursive  bool
 )
 
@@ -25,6 +26,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", os.ExpandEnv("$HOME/.orion-belt/client.yaml"), "config file path")
+	rootCmd.Flags().StringVarP(&username, "user", "u", "", "Orion Belt username for authentication")
 	rootCmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "recursively copy directories")
 }
 
@@ -65,8 +67,15 @@ func runSCP(cmd *cobra.Command, args []string) {
 	// Determine if upload or download
 	isUpload := !strings.Contains(source, ":")
 
+	usernameConfig := config.Auth.User
+	if username == "" && usernameConfig == "" {
+		logger.Fatal("Configuration error: Username is missing in your config or use --user")
+	} else if username == "" {
+		username = usernameConfig
+	}
+
 	// Copy file
-	if err := scpClient.Copy(source, destination, isUpload); err != nil {
+	if err := scpClient.Copy(username, source, destination, isUpload); err != nil {
 		logger.Fatal("Copy failed: %v", err)
 	}
 

--- a/cmd/osh/main.go
+++ b/cmd/osh/main.go
@@ -32,7 +32,7 @@ func init() {
 	rootCmd.Flags().IntVarP(&accessDuration, "duration", "d", 3600, "access duration in seconds")
 	rootCmd.Flags().StringVar(&accessReason, "reason", "", "reason for access request")
 	rootCmd.Flags().BoolVarP(&listMachines, "list", "l", false, "list available machines")
-	rootCmd.Flags().StringVarP(&username, "user", "u", "", "username for authentication (default: $USER or root)")
+	rootCmd.Flags().StringVarP(&username, "user", "u", "", "Orion Belt username for authentication")
 }
 
 func main() {
@@ -94,6 +94,13 @@ func runSSH(cmd *cobra.Command, args []string) {
 			logger.Fatal("Failed to request access: %v", err)
 		}
 		return
+	}
+
+	usernameConfig := config.Auth.User
+	if username == "" && usernameConfig == "" {
+		logger.Fatal("Configuration error: Username is missing in your config or use --user")
+	} else if username == "" {
+		username = usernameConfig
 	}
 
 	// Connect to machine

--- a/cmd/server/agent.go
+++ b/cmd/server/agent.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/zrougamed/orion-belt/pkg/common"
+	"github.com/zrougamed/orion-belt/pkg/database"
+)
+
+var (
+	agentName     string
+	agentKey      string
+	agentHostname string
+	agentPort     int
+	agentTags     []string
+)
+
+var agentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "Manage agents",
+	Long:  `Register, list, and manage Orion-Belt agents.`,
+}
+
+var agentRegisterCmd = &cobra.Command{
+	Use:   "register",
+	Short: "Register a new agent",
+	Long:  `Register a new agent machine with the Orion-Belt server.`,
+	Example: `  orion-belt-server agent register --name web-01 --key "ssh-rsa AAAAB3..." --hostname 192.168.1.100 --port 22
+  orion-belt-server agent register --name db-01 --key "ssh-ed25519 AAAAC3..." --tags environment=production,role=database`,
+	Run: runAgentRegister,
+}
+
+var agentListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all registered agents",
+	Long:  `List all agents registered with the Orion-Belt server.`,
+	Run:   runAgentList,
+}
+
+var agentDeleteCmd = &cobra.Command{
+	Use:   "delete NAME",
+	Short: "Delete an agent",
+	Long:  `Delete an agent and its associated machine record.`,
+	Args:  cobra.ExactArgs(1),
+	Run:   runAgentDelete,
+}
+
+func init() {
+	agentCmd.AddCommand(agentRegisterCmd)
+	agentCmd.AddCommand(agentListCmd)
+	agentCmd.AddCommand(agentDeleteCmd)
+
+	// Register flags
+	agentRegisterCmd.Flags().StringVarP(&agentName, "name", "n", "", "agent name (required)")
+	agentRegisterCmd.Flags().StringVarP(&agentKey, "key", "k", "", "agent SSH public key (required)")
+	agentRegisterCmd.Flags().StringVarP(&agentHostname, "hostname", "H", "", "agent hostname (defaults to name)")
+	agentRegisterCmd.Flags().IntVarP(&agentPort, "port", "p", 22, "SSH port on the agent machine")
+	agentRegisterCmd.Flags().StringSliceVarP(&agentTags, "tags", "t", []string{}, "comma-separated key=value tags")
+
+	agentRegisterCmd.MarkFlagRequired("name")
+	agentRegisterCmd.MarkFlagRequired("key")
+}
+
+func runAgentRegister(cmd *cobra.Command, args []string) {
+	logger := getLogger()
+	config, err := loadConfig()
+	if err != nil {
+		logger.Fatal("Failed to load config: %v", err)
+	}
+
+	// Initialize database
+	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
+	if err != nil {
+		logger.Fatal("Failed to create database store: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.Connect(ctx); err != nil {
+		logger.Fatal("Failed to connect to database: %v", err)
+	}
+	defer store.Close()
+
+	// Validate public key format
+	if !strings.HasPrefix(agentKey, "ssh-") {
+		logger.Fatal("Invalid SSH public key format. Key must start with ssh-rsa, ssh-ed25519, etc.")
+	}
+
+	// Use name as hostname if not provided
+	if agentHostname == "" {
+		agentHostname = agentName
+	}
+
+	// Parse tags
+	tagMap := make(map[string]string)
+	for _, tag := range agentTags {
+		parts := strings.SplitN(tag, "=", 2)
+		if len(parts) == 2 {
+			tagMap[parts[0]] = parts[1]
+		}
+	}
+
+	// Check if agent already exists
+	existingMachine, _ := store.GetMachineByName(ctx, agentName)
+	if existingMachine != nil {
+		logger.Fatal("Agent with name '%s' already exists", agentName)
+	}
+
+	// Create user account for agent
+	agentUser := common.NewUser(agentName, fmt.Sprintf("%s@agent.orion-belt", agentName), agentKey, false)
+	if err := store.CreateUser(ctx, agentUser); err != nil {
+		logger.Fatal("Failed to create agent user: %v", err)
+	}
+
+	// Create machine record
+	machine := common.NewMachine(agentName, agentHostname, agentPort, tagMap)
+	machine.AgentID = agentUser.ID
+	if err := store.CreateMachine(ctx, machine); err != nil {
+		// Rollback user creation
+		store.DeleteUser(ctx, agentUser.ID)
+		logger.Fatal("Failed to create machine: %v", err)
+	}
+
+	logger.Info("Agent registered successfully:")
+	fmt.Printf("  Name:       %s\n", agentName)
+	fmt.Printf("  User ID:    %s\n", agentUser.ID)
+	fmt.Printf("  Machine ID: %s\n", machine.ID)
+	fmt.Printf("  Hostname:   %s\n", agentHostname)
+	fmt.Printf("  Port:       %d\n", agentPort)
+	if len(tagMap) > 0 {
+		fmt.Printf("  Tags:       ")
+		first := true
+		for k, v := range tagMap {
+			if !first {
+				fmt.Printf(", ")
+			}
+			fmt.Printf("%s=%s", k, v)
+			first = false
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf("\nAgent '%s' can now connect to the server using:\n", agentName)
+	fmt.Printf("  orion-belt-agent -c /path/to/agent.yaml\n")
+}
+
+func runAgentList(cmd *cobra.Command, args []string) {
+	logger := getLogger()
+	config, err := loadConfig()
+	if err != nil {
+		logger.Fatal("Failed to load config: %v", err)
+	}
+
+	// Initialize database
+	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
+	if err != nil {
+		logger.Fatal("Failed to create database store: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.Connect(ctx); err != nil {
+		logger.Fatal("Failed to connect to database: %v", err)
+	}
+	defer store.Close()
+
+	// List all machines
+	machines, err := store.ListMachines(ctx, 1000, 0)
+	if err != nil {
+		logger.Fatal("Failed to list machines: %v", err)
+	}
+
+	if len(machines) == 0 {
+		fmt.Println("No agents registered.")
+		return
+	}
+
+	// Print table
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tHOSTNAME\tPORT\tSTATUS\tLAST SEEN\tTAGS")
+	fmt.Fprintln(w, "----\t--------\t----\t------\t---------\t----")
+
+	for _, machine := range machines {
+		status := "offline"
+		if machine.IsActive {
+			status = "online"
+		}
+
+		lastSeen := "never"
+		if machine.LastSeenAt != nil {
+			lastSeen = machine.LastSeenAt.Format("2006-01-02 15:04:05")
+		}
+
+		tags := ""
+		if len(machine.Tags) > 0 {
+			tagPairs := []string{}
+			for k, v := range machine.Tags {
+				tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, v))
+			}
+			tags = strings.Join(tagPairs, ", ")
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\n",
+			machine.Name, machine.Hostname, machine.Port, status, lastSeen, tags)
+	}
+	w.Flush()
+}
+
+func runAgentDelete(cmd *cobra.Command, args []string) {
+	agentName := args[0]
+	logger := getLogger()
+	config, err := loadConfig()
+	if err != nil {
+		logger.Fatal("Failed to load config: %v", err)
+	}
+
+	// Initialize database
+	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
+	if err != nil {
+		logger.Fatal("Failed to create database store: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.Connect(ctx); err != nil {
+		logger.Fatal("Failed to connect to database: %v", err)
+	}
+	defer store.Close()
+
+	// Get machine
+	machine, err := store.GetMachineByName(ctx, agentName)
+	if err != nil {
+		logger.Fatal("Agent '%s' not found", agentName)
+	}
+
+	// Delete machine
+	if err := store.DeleteMachine(ctx, machine.ID); err != nil {
+		logger.Fatal("Failed to delete machine: %v", err)
+	}
+
+	// Delete associated user
+	if machine.AgentID != "" {
+		if err := store.DeleteUser(ctx, machine.AgentID); err != nil {
+			logger.Warn("Failed to delete agent user: %v", err)
+		}
+	}
+
+	fmt.Printf("Agent '%s' deleted successfully.\n", agentName)
+}

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Configuration management",
+	Long:  `Manage and inspect Orion-Belt server configuration.`,
+}
+
+var configShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show configuration",
+	Long:  `Display the current configuration and its source.`,
+	Run:   runConfigShow,
+}
+
+var configPathCmd = &cobra.Command{
+	Use:   "path",
+	Short: "Show config file path",
+	Long:  `Display the path to the configuration file that will be used.`,
+	Run:   runConfigPath,
+}
+
+var configLocationsCmd = &cobra.Command{
+	Use:   "locations",
+	Short: "Show all config search paths",
+	Long:  `Display all paths where the server will search for configuration files.`,
+	Run:   runConfigLocations,
+}
+
+func init() {
+	configCmd.AddCommand(configShowCmd)
+	configCmd.AddCommand(configPathCmd)
+	configCmd.AddCommand(configLocationsCmd)
+	rootCmd.AddCommand(configCmd)
+}
+
+func runConfigShow(cmd *cobra.Command, args []string) {
+	config, err := loadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Configuration loaded successfully:")
+	fmt.Printf("\nServer:\n")
+	fmt.Printf("  Host:        %s\n", config.Server.Host)
+	fmt.Printf("  Port:        %d\n", config.Server.Port)
+	fmt.Printf("  API Port:    %d\n", config.Server.APIPort)
+	fmt.Printf("  SSH Host Key: %s\n", config.Server.SSHHostKey)
+	fmt.Printf("  Plugin Dir:  %s\n", config.Server.PluginDir)
+
+	fmt.Printf("\nDatabase:\n")
+	fmt.Printf("  Driver:      %s\n", config.Database.Driver)
+	fmt.Printf("  Connection:  %s\n", maskConnectionString(config.Database.ConnectionString))
+
+	fmt.Printf("\nRecording:\n")
+	fmt.Printf("  Enabled:     %v\n", config.Recording.Enabled)
+	fmt.Printf("  Storage:     %s\n", config.Recording.StoragePath)
+	fmt.Printf("  Retention:   %d days\n", config.Recording.RetentionDays)
+
+	if len(config.Plugins) > 0 {
+		fmt.Printf("\nPlugins:\n")
+		for name := range config.Plugins {
+			fmt.Printf("  - %s\n", name)
+		}
+	}
+}
+
+func runConfigPath(cmd *cobra.Command, args []string) {
+	path, err := findConfigPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Config file: %s\n", path)
+}
+
+func runConfigLocations(cmd *cobra.Command, args []string) {
+	paths := getConfigPaths()
+
+	fmt.Println("Config file search paths (in order):")
+	for i, path := range paths {
+		exists := "✗"
+		if _, err := os.Stat(path); err == nil {
+			exists = "✓"
+		}
+		fmt.Printf("  %d. [%s] %s\n", i+1, exists, path)
+	}
+
+	fmt.Println("\nNote: The first existing file will be used.")
+	if configFile != "" {
+		fmt.Printf("Explicitly specified: %s\n", configFile)
+	}
+}
+
+// findConfigPath returns the path to the config file that will be used
+func findConfigPath() (string, error) {
+	if configFile != "" {
+		if _, err := os.Stat(configFile); err == nil {
+			return configFile, nil
+		}
+		return "", fmt.Errorf("specified config file not found: %s", configFile)
+	}
+
+	paths := getConfigPaths()
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("no config file found in any search path")
+}
+
+// getConfigPaths returns all possible config file paths
+func getConfigPaths() []string {
+	execPath, err := os.Executable()
+	if err != nil {
+		execPath = "."
+	}
+	execDir := filepath.Dir(execPath)
+
+	return []string{
+		"/etc/orion-belt/server.yaml",
+		filepath.Join(execDir, "../config/server.yaml"),
+		filepath.Join(execDir, "config/server.yaml"),
+		"./config/server.yaml",
+		"./server.yaml",
+	}
+}
+
+// maskConnectionString masks sensitive parts of connection string
+func maskConnectionString(connStr string) string {
+	// Simple masking - hide password if present
+	// Format: postgres://user:password@host/db
+	if len(connStr) == 0 {
+		return ""
+	}
+
+	// Find password section
+	for i := 0; i < len(connStr); i++ {
+		if connStr[i] == ':' && i+1 < len(connStr) {
+			// Found potential password start
+			for j := i + 1; j < len(connStr); j++ {
+				if connStr[j] == '@' {
+					// Found password end
+					masked := connStr[:i+1] + "****" + connStr[j:]
+					return masked
+				}
+			}
+		}
+	}
+
+	return connStr
+}

--- a/cmd/server/permission.go
+++ b/cmd/server/permission.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/zrougamed/orion-belt/pkg/auth"
+	"github.com/zrougamed/orion-belt/pkg/common"
+	"github.com/zrougamed/orion-belt/pkg/database"
+)
+
+var (
+	permUsername    string
+	permMachine     string
+	permAccessType  string
+	permDuration    int
+	permGrantedBy   string
+	permRemoteUsers string
+)
+
+var permissionCmd = &cobra.Command{
+	Use:   "permission",
+	Short: "Manage permissions",
+	Long:  `Grant and revoke user permissions to access machines.`,
+}
+
+var permGrantCmd = &cobra.Command{
+	Use:   "grant",
+	Short: "Grant permission to a user",
+	Long:  `Grant a user permission to access a specific machine.`,
+	Example: `  orion-belt-server permission grant --user alice --machine web-01 --type ssh --remote-users "root,user"
+  orion-belt-server permission grant --user bob --machine db-01 --type both --duration 3600 --remote-users "postgres"`,
+	Run: runPermGrant,
+}
+
+var permListCmd = &cobra.Command{
+	Use:   "list [USERNAME]",
+	Short: "List permissions",
+	Long:  `List all permissions or permissions for a specific user.`,
+	Args:  cobra.MaximumNArgs(1),
+	Run:   runPermList,
+}
+
+var sessionCmd = &cobra.Command{
+	Use:   "session",
+	Short: "Manage sessions",
+	Long:  `View and manage active and historical sessions.`,
+}
+
+var sessionListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List sessions",
+	Long:  `List all active sessions.`,
+	Run:   runSessionList,
+}
+
+func init() {
+	permissionCmd.AddCommand(permGrantCmd)
+	permissionCmd.AddCommand(permListCmd)
+
+	sessionCmd.AddCommand(sessionListCmd)
+
+	// Permission grant flags
+	permGrantCmd.Flags().StringVarP(&permUsername, "user", "u", "", "username (required)")
+	permGrantCmd.Flags().StringVarP(&permMachine, "machine", "m", "", "machine name (required)")
+	permGrantCmd.Flags().StringVarP(&permAccessType, "type", "t", "ssh", "access type: ssh, scp, or both")
+	permGrantCmd.Flags().IntVarP(&permDuration, "duration", "d", 0, "duration in seconds (0 = permanent)")
+	permGrantCmd.Flags().StringVarP(&permGrantedBy, "granted-by", "g", "", "username of grantor (defaults to first admin or first user)")
+	permGrantCmd.Flags().StringVarP(&permRemoteUsers, "remote-users", "r", "root", "comma-separated list of allowed remote users (e.g., 'root,user,postgres')")
+
+	permGrantCmd.MarkFlagRequired("user")
+	permGrantCmd.MarkFlagRequired("machine")
+}
+
+func runPermGrant(cmd *cobra.Command, args []string) {
+	logger := getLogger()
+	config, err := loadConfig()
+	if err != nil {
+		logger.Fatal("Failed to load config: %v", err)
+	}
+
+	// Validate access type
+	if permAccessType != "ssh" && permAccessType != "scp" && permAccessType != "both" {
+		logger.Fatal("Invalid access type '%s'. Must be 'ssh', 'scp', or 'both'", permAccessType)
+	}
+
+	// Parse remote users
+	remoteUsers := []string{}
+	if permRemoteUsers != "" {
+		parts := strings.Split(permRemoteUsers, ",")
+		for _, part := range parts {
+			trimmed := strings.TrimSpace(part)
+			if trimmed != "" {
+				remoteUsers = append(remoteUsers, trimmed)
+			}
+		}
+	}
+
+	if len(remoteUsers) == 0 {
+		remoteUsers = []string{"root"} // default
+	}
+
+	// Initialize database
+	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
+	if err != nil {
+		logger.Fatal("Failed to create database store: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.Connect(ctx); err != nil {
+		logger.Fatal("Failed to connect to database: %v", err)
+	}
+	defer store.Close()
+
+	// Get user
+	user, err := store.GetUserByUsername(ctx, permUsername)
+	if err != nil {
+		logger.Fatal("User '%s' not found", permUsername)
+	}
+
+	// Get machine
+	machine, err := store.GetMachineByName(ctx, permMachine)
+	if err != nil {
+		logger.Fatal("Machine '%s' not found", permMachine)
+	}
+
+	// Determine who is granting the permission
+	var grantedBy string
+	var grantorUsername string
+
+	if permGrantedBy != "" {
+		// Use explicitly specified grantor
+		grantor, err := store.GetUserByUsername(ctx, permGrantedBy)
+		if err != nil {
+			logger.Fatal("Grantor user '%s' not found", permGrantedBy)
+		}
+		grantedBy = grantor.ID
+		grantorUsername = grantor.Username
+	} else {
+		// Auto-select: first admin user, or first user, or self
+		users, err := store.ListUsers(ctx, 100, 0)
+		if err != nil {
+			logger.Fatal("Failed to list users: %v", err)
+		}
+
+		// Look for an admin user
+		for _, u := range users {
+			if u.IsAdmin {
+				grantedBy = u.ID
+				grantorUsername = u.Username
+				break
+			}
+		}
+
+		// If no admin found, use the first user
+		if grantedBy == "" {
+			if len(users) > 0 {
+				grantedBy = users[0].ID
+				grantorUsername = users[0].Username
+				logger.Warn("No admin user found, using first user (%s) as grantor", grantorUsername)
+			} else {
+				logger.Fatal("No users in database to use as permission grantor")
+			}
+		}
+	}
+
+	// Create auth service
+	authService := auth.NewAuthService(store, logger)
+
+	// Calculate expiration
+	var duration *time.Duration
+	if permDuration > 0 {
+		d := time.Duration(permDuration) * time.Second
+		duration = &d
+	}
+
+	// Grant permission with remote users
+	if err := authService.GrantPermission(ctx, user.ID, machine.ID, permAccessType, remoteUsers, grantedBy, duration); err != nil {
+		logger.Fatal("Failed to grant permission: %v", err)
+	}
+
+	logger.Info("Permission granted successfully:")
+	fmt.Printf("  User:         %s\n", permUsername)
+	fmt.Printf("  Machine:      %s\n", permMachine)
+	fmt.Printf("  Access Type:  %s\n", permAccessType)
+	fmt.Printf("  Remote Users: %v\n", remoteUsers)
+	fmt.Printf("  Granted By:   %s\n", grantorUsername)
+	if permDuration > 0 {
+		fmt.Printf("  Duration:     %d seconds\n", permDuration)
+		expiry := time.Now().Add(time.Duration(permDuration) * time.Second)
+		fmt.Printf("  Expires:      %s\n", expiry.Format("2006-01-02 15:04:05"))
+	} else {
+		fmt.Printf("  Duration:     permanent\n")
+	}
+}
+
+func runPermList(cmd *cobra.Command, args []string) {
+	logger := getLogger()
+	config, err := loadConfig()
+	if err != nil {
+		logger.Fatal("Failed to load config: %v", err)
+	}
+
+	// Initialize database
+	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
+	if err != nil {
+		logger.Fatal("Failed to create database store: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.Connect(ctx); err != nil {
+		logger.Fatal("Failed to connect to database: %v", err)
+	}
+	defer store.Close()
+
+	var permissions []*common.Permission
+
+	if len(args) > 0 {
+		// List permissions for specific user
+		username := args[0]
+		user, err := store.GetUserByUsername(ctx, username)
+		if err != nil {
+			logger.Fatal("User '%s' not found", username)
+		}
+
+		permissions, err = store.ListUserPermissions(ctx, user.ID)
+		if err != nil {
+			logger.Fatal("Failed to list permissions: %v", err)
+		}
+
+		fmt.Printf("Permissions for user '%s':\n\n", username)
+	} else {
+		// List all permissions
+		logger.Fatal("Listing all permissions not yet implemented. Please specify a username.")
+	}
+
+	if len(permissions) == 0 {
+		fmt.Println("No permissions found.")
+		return
+	}
+
+	// Get machine and user names for display
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "MACHINE\tACCESS TYPE\tREMOTE USERS\tGRANTED\tEXPIRES")
+	fmt.Fprintln(w, "-------\t-----------\t------------\t-------\t-------")
+
+	for _, perm := range permissions {
+		machine, _ := store.GetMachine(ctx, perm.MachineID)
+		machineName := perm.MachineID
+		if machine != nil {
+			machineName = machine.Name
+		}
+
+		granted := perm.GrantedAt.Format("2006-01-02")
+
+		expires := "never"
+		if perm.ExpiresAt != nil {
+			expires = perm.ExpiresAt.Format("2006-01-02 15:04:05")
+		}
+
+		remoteUsersStr := strings.Join(perm.RemoteUsers, ",")
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			machineName, perm.AccessType, remoteUsersStr, granted, expires)
+	}
+	w.Flush()
+}
+
+func runSessionList(cmd *cobra.Command, args []string) {
+	logger := getLogger()
+	config, err := loadConfig()
+	if err != nil {
+		logger.Fatal("Failed to load config: %v", err)
+	}
+
+	// Initialize database
+	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
+	if err != nil {
+		logger.Fatal("Failed to create database store: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.Connect(ctx); err != nil {
+		logger.Fatal("Failed to connect to database: %v", err)
+	}
+	defer store.Close()
+
+	// List active sessions
+	sessions, err := store.ListActiveSessions(ctx)
+	if err != nil {
+		logger.Fatal("Failed to list sessions: %v", err)
+	}
+
+	if len(sessions) == 0 {
+		fmt.Println("No active sessions.")
+		return
+	}
+
+	// Print table
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "USER\tMACHINE\tREMOTE USER\tSTART TIME\tDURATION")
+	fmt.Fprintln(w, "----\t-------\t-----------\t----------\t--------")
+
+	for _, session := range sessions {
+		user, _ := store.GetUser(ctx, session.UserID)
+		machine, _ := store.GetMachine(ctx, session.MachineID)
+
+		username := session.UserID
+		if user != nil {
+			username = user.Username
+		}
+
+		machineName := session.MachineID
+		if machine != nil {
+			machineName = machine.Name
+		}
+
+		startTime := session.StartTime.Format("2006-01-02 15:04:05")
+		duration := time.Since(session.StartTime).Round(time.Second)
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			username, machineName, session.RemoteUser, startTime, duration)
+	}
+	w.Flush()
+}

--- a/cmd/server/user.go
+++ b/cmd/server/user.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/zrougamed/orion-belt/pkg/common"
+	"github.com/zrougamed/orion-belt/pkg/database"
+)
+
+var (
+	userName  string
+	userEmail string
+	userKey   string
+	userAdmin bool
+)
+
+var userCmd = &cobra.Command{
+	Use:   "user",
+	Short: "Manage users",
+	Long:  `Create, list, and manage Orion-Belt users.`,
+}
+
+var userCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new user",
+	Long:  `Create a new user account in the Orion-Belt system.`,
+	Example: `  orion-belt-server user create --name alice --email alice@example.com --key "ssh-rsa AAAAB3..."
+  orion-belt-server user create --name admin --email admin@example.com --key "ssh-ed25519 AAAAC3..." --admin`,
+	Run: runUserCreate,
+}
+
+var userListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all users",
+	Long:  `List all users registered in the Orion-Belt system.`,
+	Run:   runUserList,
+}
+
+var userDeleteCmd = &cobra.Command{
+	Use:   "delete USERNAME",
+	Short: "Delete a user",
+	Long:  `Delete a user account from the Orion-Belt system.`,
+	Args:  cobra.ExactArgs(1),
+	Run:   runUserDelete,
+}
+
+func init() {
+	userCmd.AddCommand(userCreateCmd)
+	userCmd.AddCommand(userListCmd)
+	userCmd.AddCommand(userDeleteCmd)
+
+	// Create flags
+	userCreateCmd.Flags().StringVarP(&userName, "name", "n", "", "username (required)")
+	userCreateCmd.Flags().StringVarP(&userEmail, "email", "e", "", "user email (required)")
+	userCreateCmd.Flags().StringVarP(&userKey, "key", "k", "", "user SSH public key (required)")
+	userCreateCmd.Flags().BoolVarP(&userAdmin, "admin", "a", false, "grant admin privileges")
+
+	userCreateCmd.MarkFlagRequired("name")
+	userCreateCmd.MarkFlagRequired("email")
+	userCreateCmd.MarkFlagRequired("key")
+}
+
+func runUserCreate(cmd *cobra.Command, args []string) {
+	logger := getLogger()
+	config, err := loadConfig()
+	if err != nil {
+		logger.Fatal("Failed to load config: %v", err)
+	}
+
+	// Initialize database
+	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
+	if err != nil {
+		logger.Fatal("Failed to create database store: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.Connect(ctx); err != nil {
+		logger.Fatal("Failed to connect to database: %v", err)
+	}
+	defer store.Close()
+
+	// Validate public key format
+	if !strings.HasPrefix(userKey, "ssh-") {
+		logger.Fatal("Invalid SSH public key format. Key must start with ssh-rsa, ssh-ed25519, etc.")
+	}
+
+	// Check if user already exists
+	existingUser, _ := store.GetUserByUsername(ctx, userName)
+	if existingUser != nil {
+		logger.Fatal("User with username '%s' already exists", userName)
+	}
+
+	// Create user
+	user := common.NewUser(userName, userEmail, userKey, userAdmin)
+	if err := store.CreateUser(ctx, user); err != nil {
+		logger.Fatal("Failed to create user: %v", err)
+	}
+
+	logger.Info("User created successfully:")
+	fmt.Printf("  Username: %s\n", userName)
+	fmt.Printf("  Email:    %s\n", userEmail)
+	fmt.Printf("  User ID:  %s\n", user.ID)
+	fmt.Printf("  Admin:    %v\n", userAdmin)
+
+	fmt.Printf("\nUser '%s' can now connect using:\n", userName)
+	fmt.Printf("  osh machine-name\n")
+}
+
+func runUserList(cmd *cobra.Command, args []string) {
+	logger := getLogger()
+	config, err := loadConfig()
+	if err != nil {
+		logger.Fatal("Failed to load config: %v", err)
+	}
+
+	// Initialize database
+	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
+	if err != nil {
+		logger.Fatal("Failed to create database store: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.Connect(ctx); err != nil {
+		logger.Fatal("Failed to connect to database: %v", err)
+	}
+	defer store.Close()
+
+	// List all users
+	users, err := store.ListUsers(ctx, 1000, 0)
+	if err != nil {
+		logger.Fatal("Failed to list users: %v", err)
+	}
+
+	if len(users) == 0 {
+		fmt.Println("No users registered.")
+		return
+	}
+
+	// Print table
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "USERNAME\tEMAIL\tADMIN\tCREATED")
+	fmt.Fprintln(w, "--------\t-----\t-----\t-------")
+
+	for _, user := range users {
+		admin := "no"
+		if user.IsAdmin {
+			admin = "yes"
+		}
+
+		created := user.CreatedAt.Format("2006-01-02 15:04:05")
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			user.Username, user.Email, admin, created)
+	}
+	w.Flush()
+}
+
+func runUserDelete(cmd *cobra.Command, args []string) {
+	username := args[0]
+	logger := getLogger()
+	config, err := loadConfig()
+	if err != nil {
+		logger.Fatal("Failed to load config: %v", err)
+	}
+
+	// Initialize database
+	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
+	if err != nil {
+		logger.Fatal("Failed to create database store: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.Connect(ctx); err != nil {
+		logger.Fatal("Failed to connect to database: %v", err)
+	}
+	defer store.Close()
+
+	// Get user
+	user, err := store.GetUserByUsername(ctx, username)
+	if err != nil {
+		logger.Fatal("User '%s' not found", username)
+	}
+
+	// Delete user
+	if err := store.DeleteUser(ctx, user.ID); err != nil {
+		logger.Fatal("Failed to delete user: %v", err)
+	}
+
+	fmt.Printf("User '%s' deleted successfully.\n", username)
+}

--- a/docs/SREVER-CLI.md
+++ b/docs/SREVER-CLI.md
@@ -1,0 +1,399 @@
+# Orion-Belt Server CLI
+
+Command-line interface for managing the Orion-Belt server, agents, users, and permissions.
+
+## Configuration
+
+The server looks for configuration files in the following order:
+
+1. Path specified with `--config` flag
+2. `/etc/orion-belt/server.yaml`
+3. `<executable-dir>/../config/server.yaml`
+4. `<executable-dir>/config/server.yaml`
+5. `./config/server.yaml`
+6. `./server.yaml`
+
+### Check Configuration
+
+```bash
+# Show which config file will be used
+orion-belt-server config path
+
+# Show all search paths
+orion-belt-server config locations
+
+# Display current configuration
+orion-belt-server config show
+```
+
+Example output:
+```
+$ orion-belt-server config locations
+Config file search paths (in order):
+  1. [✗] /etc/orion-belt/server.yaml
+  2. [✓] /opt/orion-belt/config/server.yaml
+  3. [✗] /opt/orion-belt/bin/config/server.yaml
+  4. [✗] ./config/server.yaml
+  5. [✗] ./server.yaml
+
+Note: The first existing file will be used.
+```
+
+## Server Management
+
+### Start the Server
+
+```bash
+# Start with default config
+orion-belt-server
+orion-belt-server start
+
+# Start with specific config
+orion-belt-server --config /path/to/config.yaml
+
+# Start with debug logging
+orion-belt-server --log-level debug
+```
+
+## Agent Management
+
+### Register an Agent
+
+```bash
+orion-belt-server agent register \
+  --name <agent-name> \
+  --key "<ssh-public-key>" \
+  [--hostname <hostname>] \
+  [--port <port>] \
+  [--tags key1=value1,key2=value2]
+```
+
+**Examples:**
+
+```bash
+# Basic registration
+orion-belt-server agent register \
+  --name machine-32 \
+  --key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKHHyXRMTiKfb3h..."
+
+# With hostname and tags
+orion-belt-server agent register \
+  --name web-01 \
+  --key "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC..." \
+  --hostname 192.168.1.100 \
+  --port 22 \
+  --tags environment=production,role=web
+
+# With multiple tags
+orion-belt-server agent register \
+  --name db-01 \
+  --key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample..." \
+  --tags environment=production,role=database,tier=backend
+```
+
+**Output:**
+```
+Agent registered successfully:
+  Name:       machine-32
+  User ID:    uuid-abc-123
+  Machine ID: uuid-def-456
+  Hostname:   machine-32
+  Port:       22
+
+Agent 'machine-32' can now connect to the server using:
+  orion-belt-agent -c /path/to/agent.yaml
+```
+
+### List Agents
+
+```bash
+orion-belt-server agent list
+```
+
+**Output:**
+```
+NAME         HOSTNAME       PORT  STATUS   LAST SEEN             TAGS
+----         --------       ----  ------   ---------             ----
+machine-32   machine-32     22    online   2026-01-04 10:30:15   
+web-01       192.168.1.100  22    online   2026-01-04 10:25:00   environment=production, role=web
+db-01        192.168.1.101  22    offline  2026-01-04 09:15:30   environment=production, role=database
+```
+
+### Delete an Agent
+
+```bash
+orion-belt-server agent delete <agent-name>
+```
+
+**Example:**
+```bash
+orion-belt-server agent delete machine-32
+# Output: Agent 'machine-32' deleted successfully.
+```
+
+## User Management
+
+### Create a User
+
+```bash
+orion-belt-server user create \
+  --name <username> \
+  --email <email> \
+  --key "<ssh-public-key>" \
+  [--admin]
+```
+
+**Examples:**
+
+```bash
+# Create regular user
+orion-belt-server user create \
+  --name alice \
+  --email alice@example.com \
+  --key "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC..."
+
+# Create admin user
+orion-belt-server user create \
+  --name admin \
+  --email admin@example.com \
+  --key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample..." \
+  --admin
+```
+
+**Output:**
+```
+User created successfully:
+  Username: alice
+  Email:    alice@example.com
+  User ID:  uuid-xyz-789
+  Admin:    false
+
+User 'alice' can now connect using:
+  osh machine-name
+```
+
+### List Users
+
+```bash
+orion-belt-server user list
+```
+
+**Output:**
+```
+USERNAME  EMAIL                  ADMIN  CREATED
+--------  -----                  -----  -------
+admin     admin@example.com      yes    2026-01-04 08:00:00
+alice     alice@example.com      no     2026-01-04 09:15:30
+bob       bob@example.com        no     2026-01-04 10:30:15
+```
+
+### Delete a User
+
+```bash
+orion-belt-server user delete <username>
+```
+
+**Example:**
+```bash
+orion-belt-server user delete alice
+# Output: User 'alice' deleted successfully.
+```
+
+## Permission Management
+
+### Grant Permission
+
+```bash
+orion-belt-server permission grant \
+  --user <username> \
+  --machine <machine-name> \
+  --type <access-type> \
+  [--duration <seconds>]
+```
+
+**Access Types:**
+- `ssh` - SSH access only
+- `scp` - SCP (file transfer) access only
+- `both` - Both SSH and SCP access
+
+**Examples:**
+
+```bash
+# Grant permanent SSH access
+orion-belt-server permission grant \
+  --user alice \
+  --machine web-01 \
+  --type ssh
+
+# Grant temporary access (1 hour = 3600 seconds)
+orion-belt-server permission grant \
+  --user bob \
+  --machine db-01 \
+  --type both \
+  --duration 3600
+
+# Grant temporary access (8 hours)
+orion-belt-server permission grant \
+  --user alice \
+  --machine db-01 \
+  --type ssh \
+  --duration 28800
+```
+
+**Output:**
+```
+Permission granted successfully:
+  User:        alice
+  Machine:     web-01
+  Access Type: ssh
+  Duration:    permanent
+```
+
+Or with expiration:
+```
+Permission granted successfully:
+  User:        bob
+  Machine:     db-01
+  Access Type: both
+  Duration:    3600 seconds
+  Expires:     2026-01-04 11:30:15
+```
+
+### List Permissions
+
+```bash
+# List permissions for a specific user
+orion-belt-server permission list <username>
+```
+
+**Example:**
+```bash
+orion-belt-server permission list alice
+```
+
+**Output:**
+```
+Permissions for user 'alice':
+
+MACHINE  ACCESS TYPE  GRANTED     EXPIRES
+-------  -----------  -------     -------
+web-01   ssh          2026-01-04  never
+db-01    ssh          2026-01-04  2026-01-04 11:30:15
+```
+
+## Session Management
+
+### List Active Sessions
+
+```bash
+orion-belt-server session list
+```
+
+**Output:**
+```
+USER   MACHINE  START TIME           DURATION
+----   -------  ----------           --------
+alice  web-01   2026-01-04 10:30:15  5m30s
+bob    db-01    2026-01-04 10:32:00  3m45s
+```
+
+## Common Workflows
+
+### 1. Register and Grant Access to a New Machine
+
+```bash
+# 1. Register the agent
+orion-belt-server agent register \
+  --name app-server-01 \
+  --key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample..." \
+  --hostname 10.0.1.50 \
+  --tags environment=production,role=application
+
+# 2. Grant access to a user
+orion-belt-server permission grant \
+  --user alice \
+  --machine app-server-01 \
+  --type ssh
+
+# 3. Verify
+orion-belt-server agent list
+orion-belt-server permission list alice
+```
+
+### 2. Onboard a New User
+
+```bash
+# 1. Create the user
+orion-belt-server user create \
+  --name charlie \
+  --email charlie@example.com \
+  --key "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCExample..."
+
+# 2. Grant access to specific machines
+orion-belt-server permission grant \
+  --user charlie \
+  --machine web-01 \
+  --type ssh
+
+orion-belt-server permission grant \
+  --user charlie \
+  --machine app-server-01 \
+  --type both
+
+# 3. Verify
+orion-belt-server permission list charlie
+```
+
+### 3. Grant Temporary Emergency Access
+
+```bash
+# Grant 2-hour access to production database
+orion-belt-server permission grant \
+  --user alice \
+  --machine prod-db-01 \
+  --type ssh \
+  --duration 7200
+```
+
+## Global Flags
+
+All commands support these global flags:
+
+```bash
+-c      Config file path (default: auto-detect)
+-l      Log level: debug, info, warn, error (default: info)
+```
+
+**Examples:**
+
+```bash
+# Use specific config
+orion-belt-server -c /custom/path/config.yaml agent list
+
+# Enable debug logging
+orion-belt-server -l debug user list
+
+# Combine both
+orion-belt-server -c /custom/config.yaml -l debug agent register ...
+```
+
+## Tips
+
+1. **Check config before running commands:**
+
+```bash
+orion-belt-server config path
+```
+2. **Use tab completion** (if shell completion is set up)
+3. **SSH key format:** Keys must start with `ssh-rsa`, `ssh-ed25519`, `ecdsa-sha2-nistp256`, etc.
+4. **View all available commands:**
+```bash
+orion-belt-server --help
+orion-belt-server agent --help
+orion-belt-server user --help
+```
+5. **Durations are in seconds:**
+   - 1 hour = 3600
+   - 8 hours = 28800
+   - 1 day = 86400
+   - 1 week = 604800

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -239,9 +239,10 @@ func (s *APIServer) registerClient(c *gin.Context) {
 
 // CreateAccessRequestRequest represents an access request creation
 type CreateAccessRequestRequest struct {
-	MachineID string `json:"machine_id" binding:"required"`
-	Reason    string `json:"reason" binding:"required"`
-	Duration  int    `json:"duration" binding:"required"` // in seconds
+	MachineID   string   `json:"machine_id" binding:"required"`
+	RemoteUsers []string `json:"remote_users" binding:"required"`
+	Reason      string   `json:"reason" binding:"required"`
+	Duration    int      `json:"duration" binding:"required"` // in seconds
 }
 
 // createAccessRequest handles access request creation
@@ -256,7 +257,13 @@ func (s *APIServer) createAccessRequest(c *gin.Context) {
 	userID, _ := c.Get("user_id")
 
 	ctx := context.Background()
-	accessReq := common.NewAccessRequest(userID.(string), req.MachineID, req.Reason, req.Duration)
+	accessReq := common.NewAccessRequest(
+		userID.(string),
+		req.MachineID,
+		req.RemoteUsers,
+		req.Reason,
+		req.Duration,
+	)
 
 	if err := s.store.CreateAccessRequest(ctx, accessReq); err != nil {
 		s.logger.Error("Failed to create access request: %v", err)

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -36,6 +36,7 @@ type DatabaseConfig struct {
 // AuthConfig contains authentication configuration
 type AuthConfig struct {
 	KeyFile         string `yaml:"key_file,omitempty"`
+	User            string `yaml:"user,omitempty"`
 	ReBACEnabled    bool   `yaml:"rebac_enabled,omitempty"`
 	AllowTempAccess bool   `yaml:"allow_temp_access,omitempty"`
 }

--- a/pkg/database/store.go
+++ b/pkg/database/store.go
@@ -48,6 +48,7 @@ type Store interface {
 	ListUserPermissions(ctx context.Context, userID string) ([]*common.Permission, error)
 	ListMachinePermissions(ctx context.Context, machineID string) ([]*common.Permission, error)
 	HasPermission(ctx context.Context, userID, machineID, accessType string) (bool, error)
+	HasPermissionWithRemoteUser(ctx context.Context, userID, machineID, accessType, remoteUser string) (bool, error)
 
 	// Audit log operations
 	CreateAuditLog(ctx context.Context, log *common.AuditLog) error


### PR DESCRIPTION
# Add Remote User Specification for SSH/SCP Connections

## Overview
This PR implements **remote user specification** for Orion-Belt connections, allowing users to specify which remote account to authenticate as when connecting to target machines through the gateway.

## Motivation
Previously, all connections defaulted to a single remote user (typically root), limiting flexibility and violating the principle of least privilege. This change enables:
- Fine-grained per-user access control (e.g., alice can SSH as webadmin but not root)
- Better audit trails showing which remote accounts were accessed
- Compliance with security policies requiring non-root access
- Support for applications requiring specific service accounts

## Changes

### Client Tools (osh/ocp)
- **New `--user` flag**: Explicitly specify Orion Belt username
```bash
  osh --user alice root@web-01
  ocp --user deploy local.tar.gz web-01:/tmp/
```
- **user@machine syntax**: Standard SSH-style notation
```bash
  osh alice@web-01
  ocp alice@web-01:/var/log/app.log ./
```
- **Config file support**: Set default remote user in `~/.orion-belt/client.yaml`
```yaml
  auth:
    user: "deploy"  # default remote user
```

### Server-Side
- **Permission granularity**: Permissions now include `remote_users` array
```sql
  -- Old: user can access machine (any remote account)
  -- New: user can access specific remote accounts on machine
```
- **Enhanced session tracking**: Sessions record which remote user was accessed
- **Agent CLI**: New `orion-belt-server agent` commands for registration
  - `agent register`: Register new agents with public keys
  - `agent list`: Show all registered agents with status
  - `agent delete`: Remove agents

### Database
- **Migration**: Add `remote_users TEXT[]` column to permissions table
- **New query**: `HasPermissionWithRemoteUser()` validates user-specific access
- **Session tracking**: Add `remote_user VARCHAR(255)` to sessions table

## Backward Compatibility
**Fully backward compatible**
- Connections without user specification default to `root`
- Existing permissions continue to work (treated as allowing all remote users)
- No breaking API changes

## Security Implications
- **Improved**: Granular control over which remote accounts can be accessed
- **Improved**: Better audit trails with remote user information
- **Note**: Admins must update permissions to restrict remote user access (defaults to allowing all)

## Testing
- [x] osh connects with `--user` flag
- [x] ocp transfers files with user@machine syntax  
- [x] Config file default user works correctly
- [x] Permission checks validate remote user correctly
- [x] Sessions record remote user in database
- [x] Agent registration via CLI succeeds
- [x] Error messages display helpful guidance

## Examples

### Grant alice SSH access as 'deploy' user on web-01
```bash
orion-belt-server grant-permission \
  --user alice \
  --machine web-01 \
  --access-type ssh \
  --remote-users deploy
```

### Connect as deploy user
```bash
# Using flag
osh --user deploy web-01

# Using @ syntax
osh deploy@web-01

# Using config default
cat ~/.orion-belt/client.yaml
# auth:
#   user: deploy
osh web-01  # connects as deploy
```

## Migration Guide
For existing deployments:

1. **Update permissions** to specify allowed remote users:
```sql
   UPDATE permissions 
   SET remote_users = ARRAY['root', 'user'] 
   WHERE remote_users IS NULL;
```

2. **Update client configs** with default users:
```yaml
   auth:
     user: "alice"
```

3. **Test access** before enforcing strict policies
