### PR TITLE
Feature: Access Request Workflow & Machine Listing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GO=go
 GOFLAGS=-v
 
 # Build all components
-build: build-server build-client build-agent
+build: build-server build-client build-admin build-agent
 
 # Build server
 build-server:
@@ -24,6 +24,12 @@ build-client:
 	@mkdir -p $(BUILD_DIR)
 	$(GO) build $(GOFLAGS) -o $(BUILD_DIR)/osh ./cmd/osh
 	$(GO) build $(GOFLAGS) -o $(BUILD_DIR)/ocp ./cmd/ocp
+
+# Build admin
+build-admin:
+	@echo "Building admin..."
+	@mkdir -p $(BUILD_DIR)
+	$(GO) build $(GOFLAGS) -o $(BUILD_DIR)/oadmin ./cmd/oadmin
 
 # Build agent
 build-agent:

--- a/cmd/oadmin/main.go
+++ b/cmd/oadmin/main.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/zrougamed/orion-belt/pkg/client"
+	"github.com/zrougamed/orion-belt/pkg/common"
+	"golang.org/x/crypto/ssh"
+)
+
+var (
+	configFile string
+	username   string
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "oadmin",
+	Short: "Orion-Belt Admin CLI",
+	Long:  `oadmin is the Orion-Belt admin tool for managing access requests and system operations.`,
+}
+
+var requestsCmd = &cobra.Command{
+	Use:   "requests",
+	Short: "Manage access requests",
+	Long:  `List, approve, and reject access requests.`,
+}
+
+var listRequestsCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List pending access requests",
+	Run:   runListRequests,
+}
+
+var approveCmd = &cobra.Command{
+	Use:   "approve [request-id]",
+	Short: "Approve an access request",
+	Args:  cobra.ExactArgs(1),
+	Run:   runApprove,
+}
+
+var rejectCmd = &cobra.Command{
+	Use:   "reject [request-id]",
+	Short: "Reject an access request",
+	Args:  cobra.ExactArgs(1),
+	Run:   runReject,
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", os.ExpandEnv("$HOME/.orion-belt/client.yaml"), "config file path")
+	rootCmd.PersistentFlags().StringVarP(&username, "user", "u", "", "Orion Belt username for authentication")
+
+	requestsCmd.AddCommand(listRequestsCmd)
+	requestsCmd.AddCommand(approveCmd)
+	requestsCmd.AddCommand(rejectCmd)
+	rootCmd.AddCommand(requestsCmd)
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func getAPIClient() (*client.APIClient, error) {
+	logger := common.NewLogger(common.INFO)
+
+	// Load configuration
+	config, err := common.LoadConfig(configFile)
+	if err != nil {
+		// Use default config if file doesn't exist
+		config = &common.Config{
+			Server: common.ServerConfig{
+				Host: "localhost",
+				Port: 2222,
+			},
+			Auth: common.AuthConfig{
+				KeyFile: os.ExpandEnv("$HOME/.ssh/id_rsa"),
+			},
+		}
+	}
+
+	// Get API endpoint
+	apiEndpoint := config.Server.APIEndpoint
+	if apiEndpoint == "" {
+		apiEndpoint = fmt.Sprintf("http://%s:8080", config.Server.Host)
+	}
+
+	// Load SSH key
+	keyData, err := os.ReadFile(config.Auth.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read SSH key: %w", err)
+	}
+
+	signer, err := ssh.ParsePrivateKey(keyData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	// Get username
+	user := username
+	if user == "" {
+		user = config.Auth.User
+		if user == "" {
+			user = os.Getenv("USER")
+			if user == "" {
+				return nil, fmt.Errorf("username not configured")
+			}
+		}
+	}
+
+	return client.NewAPIClient(apiEndpoint, user, signer, logger)
+}
+
+func runListRequests(cmd *cobra.Command, args []string) {
+	apiClient, err := getAPIClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	requests, err := apiClient.ListPendingAccessRequests()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing requests: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(requests) == 0 {
+		fmt.Println("No pending access requests.")
+		return
+	}
+
+	fmt.Printf("Pending Access Requests (%d):\n\n", len(requests))
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "REQUEST ID\tUSER\tMACHINE\tREMOTE USER\tREASON\tDURATION\tREQUESTED")
+	fmt.Fprintln(w, "----------\t----\t-------\t-----------\t------\t--------\t---------")
+
+	for _, req := range requests {
+		duration := formatDuration(time.Duration(req.Duration) * time.Second)
+		requestedAgo := formatDuration(time.Since(req.RequestedAt))
+		remoteUser := "default"
+		if len(req.RemoteUsers) > 0 {
+			remoteUser = req.RemoteUsers[0]
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			req.ID,
+			req.UserID[:8]+"...",
+			req.MachineID[:8]+"...",
+			remoteUser,
+			truncate(req.Reason, 20),
+			duration,
+			requestedAgo,
+		)
+	}
+
+	w.Flush()
+
+	fmt.Println("\nUse 'oadmin requests approve <request-id>' to approve")
+	fmt.Println("Use 'oadmin requests reject <request-id>' to reject")
+}
+
+func runApprove(cmd *cobra.Command, args []string) {
+	requestID := args[0]
+
+	apiClient, err := getAPIClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Get current user ID (reviewer)
+	// For now, we'll use the username as reviewer ID
+	// In production, you'd want to get the actual user ID from the API
+	reviewerID := username
+	if reviewerID == "" {
+		reviewerID = os.Getenv("USER")
+	}
+
+	if err := apiClient.ApproveAccessRequest(requestID, reviewerID); err != nil {
+		fmt.Fprintf(os.Stderr, "Error approving request: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("✓ Access request %s approved\n", requestID[:8]+"...")
+}
+
+func runReject(cmd *cobra.Command, args []string) {
+	requestID := args[0]
+
+	apiClient, err := getAPIClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Get current user ID (reviewer)
+	reviewerID := username
+	if reviewerID == "" {
+		reviewerID = os.Getenv("USER")
+	}
+
+	if err := apiClient.RejectAccessRequest(requestID, reviewerID); err != nil {
+		fmt.Fprintf(os.Stderr, "Error rejecting request: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("✗ Access request %s rejected\n", requestID[:8]+"...")
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	} else if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	} else if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	} else {
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -1,0 +1,247 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/zrougamed/orion-belt/pkg/common"
+	"golang.org/x/crypto/ssh"
+)
+
+// APIClient handles REST API communication with the Orion-Belt server
+type APIClient struct {
+	baseURL    string
+	httpClient *http.Client
+	apiKey     string
+	logger     *common.Logger
+}
+
+// Machine represents a machine from the API
+type Machine struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Hostname   string            `json:"hostname"`
+	Port       int               `json:"port"`
+	Tags       map[string]string `json:"tags"`
+	AgentID    string            `json:"agent_id"`
+	IsActive   bool              `json:"is_active"`
+	LastSeenAt *time.Time        `json:"last_seen_at"`
+	CreatedAt  time.Time         `json:"created_at"`
+	UpdatedAt  time.Time         `json:"updated_at"`
+}
+
+// AccessRequest represents an access request from the API
+type AccessRequest struct {
+	ID          string     `json:"id"`
+	UserID      string     `json:"user_id"`
+	MachineID   string     `json:"machine_id"`
+	RemoteUsers []string   `json:"remote_users"`
+	Reason      string     `json:"reason"`
+	Duration    int        `json:"duration"`
+	Status      string     `json:"status"`
+	RequestedAt time.Time  `json:"requested_at"`
+	ReviewedAt  *time.Time `json:"reviewed_at"`
+	ReviewedBy  *string    `json:"reviewed_by"`
+	ExpiresAt   *time.Time `json:"expires_at"`
+}
+
+// NewAPIClient creates a new API client with authentication
+func NewAPIClient(baseURL, username string, signer ssh.Signer, logger *common.Logger) (*APIClient, error) {
+	client := &APIClient{
+		baseURL:    baseURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		logger:     logger,
+	}
+
+	// Authenticate and get API key
+	if err := client.authenticate(username, signer); err != nil {
+		return nil, fmt.Errorf("authentication failed: %w", err)
+	}
+
+	return client, nil
+}
+
+// authenticate obtains an API key using SSH public key authentication
+func (c *APIClient) authenticate(username string, signer ssh.Signer) error {
+	// Get the public key in OpenSSH authorized_keys format
+	publicKey := string(ssh.MarshalAuthorizedKey(signer.PublicKey()))
+
+	// Send login request with public key
+	loginReq := map[string]interface{}{
+		"username":   username,
+		"public_key": publicKey,
+	}
+
+	var loginResp struct {
+		APIKey    string    `json:"api_key"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+
+	// Use the key-based login endpoint
+	if err := c.doRequestNoAuth("POST", "/api/v1/public/login/key", loginReq, &loginResp); err != nil {
+		return err
+	}
+
+	if loginResp.APIKey == "" {
+		return fmt.Errorf("no API key returned from login")
+	}
+
+	c.apiKey = loginResp.APIKey
+	c.logger.Info("Successfully authenticated, API key expires at: %s", loginResp.ExpiresAt.Format(time.RFC3339))
+	return nil
+}
+
+// doRequestNoAuth performs an HTTP request without authentication (for login)
+func (c *APIClient) doRequestNoAuth(method, path string, body interface{}, result interface{}) error {
+	var reqBody io.Reader
+	if body != nil {
+		jsonData, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request: %w", err)
+		}
+		reqBody = bytes.NewBuffer(jsonData)
+	}
+
+	req, err := http.NewRequest(method, c.baseURL+path, reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("failed to parse response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// doRequest performs an HTTP request to the API
+func (c *APIClient) doRequest(method, path string, body interface{}, result interface{}) error {
+	var reqBody io.Reader
+	if body != nil {
+		jsonData, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request: %w", err)
+		}
+		reqBody = bytes.NewBuffer(jsonData)
+	}
+
+	req, err := http.NewRequest(method, c.baseURL+path, reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("X-API-Key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("failed to parse response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ListMachines retrieves all available machines
+func (c *APIClient) ListMachines() ([]Machine, error) {
+	var machines []Machine
+	if err := c.doRequest("GET", "/api/v1/machines", nil, &machines); err != nil {
+		return nil, err
+	}
+	return machines, nil
+}
+
+// GetMachineByName retrieves a machine by its name
+func (c *APIClient) GetMachineByName(name string) (*Machine, error) {
+	machines, err := c.ListMachines()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, machine := range machines {
+		if machine.Name == name {
+			return &machine, nil
+		}
+	}
+
+	return nil, fmt.Errorf("machine %s not found", name)
+}
+
+// CreateAccessRequest creates a new access request
+func (c *APIClient) CreateAccessRequest(request map[string]interface{}) (*AccessRequest, error) {
+	var accessReq AccessRequest
+	if err := c.doRequest("POST", "/api/v1/access-requests", request, &accessReq); err != nil {
+		return nil, err
+	}
+	return &accessReq, nil
+}
+
+// GetAccessRequest retrieves an access request by ID
+func (c *APIClient) GetAccessRequest(requestID string) (*AccessRequest, error) {
+	var accessReq AccessRequest
+	if err := c.doRequest("GET", "/api/v1/access-requests/"+requestID, nil, &accessReq); err != nil {
+		return nil, err
+	}
+	return &accessReq, nil
+}
+
+// ListPendingAccessRequests retrieves all pending access requests (admin only)
+func (c *APIClient) ListPendingAccessRequests() ([]AccessRequest, error) {
+	var requests []AccessRequest
+	if err := c.doRequest("GET", "/api/v1/access-requests/pending", nil, &requests); err != nil {
+		return nil, err
+	}
+	return requests, nil
+}
+
+// ApproveAccessRequest approves an access request (admin only)
+func (c *APIClient) ApproveAccessRequest(requestID, reviewerID string) error {
+	req := map[string]string{"reviewer_id": reviewerID}
+	return c.doRequest("POST", fmt.Sprintf("/api/v1/admin/access-requests/%s/approve", requestID), req, nil)
+}
+
+// RejectAccessRequest rejects an access request (admin only)
+func (c *APIClient) RejectAccessRequest(requestID, reviewerID string) error {
+	req := map[string]string{"reviewer_id": reviewerID}
+	return c.doRequest("POST", fmt.Sprintf("/api/v1/admin/access-requests/%s/reject", requestID), req, nil)
+}


### PR DESCRIPTION
### Summary
Implements the complete access request workflow allowing users to request temporary access to machines, with admin approval and automatic permission grants. Also adds machine listing functionality for the client tools.

### Changes

#### Core Features

**Machine Listing (`osh --list`)**
- Lists all registered machines with formatted table
- Shows machine status (online/offline)
- Displays last seen timestamps
- Color-coded status indicators

**Access Request Flow**
- Users can request temporary access via `osh --request-access`
- Real-time polling for approval status (5 second intervals)
- Automatic timeout after 5 minutes
- Visual progress indicators
- Support for specific remote users (e.g., `root@machine-29`)

**Admin Management**
- New `oadmin` CLI tool for managing requests
- `oadmin requests list` - View all pending requests
- `oadmin requests approve <id>` - Approve a request
- `oadmin requests reject <id>` - Reject a request
- Automatic permission creation on approval

### Technical Details

#### Authentication Flow
1. Client sends username + public_key to `/login/key` ( TODO: work on the keys/secrets in the roadmap )
2. Server verifies public key against database
3. Server generates 24-hour API key using `GenerateAPIKey()`
4. Client uses API key in `X-API-Key` header for all requests

#### Access Request Flow
```
User Request → API Creation → Database INSERT → Poll Status → 
Admin Approval → Permission Grant → User Notified → SSH Access
```


### Usage Examples

#### User Workflow
```bash
# List available machines
osh --list --user alice

# Request access
osh --request-access root@machine-29 \
  --reason "Emergency maintenance" \
  --duration 3600 \
  --user alice

# Wait for approval...
# Once approved, connect
osh root@machine-29 --user alice
```

#### Admin Workflow
```bash
# Check pending requests
oadmin requests list --user bob

# Approve a request
oadmin requests approve 550e8400-e29b-41d4-a716-446655440000 --user bob

# Or reject
oadmin requests reject 7c9e6679-7425-40de-944b-e07fc1f90ae7 --user bob
```

### Breaking Changes
N/A

### Migration Required
N/A

### Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated
- [x] No new warnings generated
- [x] Tests pass locally
- [x] Database queries tested
- [x] Error handling comprehensive

### Related Issues
N/A

