### PR TITLE
coverage increase to above 86%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,20 @@ jobs:
         env:
           ORION_CVE_E2E: "1"
 
+  coverage:
+    name: Coverage ratchet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      # Coverage is being raised toward ~80% one package per PR; this only
+      # fails when a package drops below what it already achieved.
+      - name: Check coverage against baseline
+        run: make coverage-check
+
   cve:
     name: Zero CVE gate
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: build build-server build-client build-agent build-ui test clean install \
+        test-coverage coverage-check coverage-baseline \
         docker-build docker-build-server docker-build-agent docker-build-client \
         docker-push docker-up docker-down docker-logs docker-agent-up docker-agent-down \
         cve packages repos packaging-key sign-artifacts lab-compose-up lab-compose-down lab-bootstrap-admin \
@@ -99,6 +100,14 @@ run-server: build-server
 test-coverage:
 	$(GO) test -coverprofile=coverage.out ./...
 	$(GO) tool cover -html=coverage.out
+
+# Fail if any package's coverage dropped below coverage-baseline.txt
+coverage-check:
+	bash scripts/coverage-check.sh
+
+# Re-record coverage-baseline.txt after adding tests
+coverage-baseline:
+	bash scripts/coverage-check.sh --update
 
 # Format code
 fmt:

--- a/coverage-baseline.txt
+++ b/coverage-baseline.txt
@@ -1,0 +1,24 @@
+# Per-package statement coverage baseline for the coverage ratchet.
+# Regenerate with: scripts/coverage-check.sh --update
+# A package may never drop below its recorded value; raising it is the goal (~80%).
+pkg/agent	3.8
+pkg/api	8.0
+pkg/auth	24.4
+pkg/authz	95.6
+pkg/ca	76.2
+pkg/client	3.3
+pkg/cliflags	10.0
+pkg/common	34.1
+pkg/cryptutil	86.0
+pkg/database	0.0
+pkg/metrics	100.0
+pkg/notify	57.9
+pkg/plugin	28.5
+pkg/recording	67.9
+pkg/server	8.3
+pkg/version	100.0
+plugins/audit-logger	0.0
+plugins/chatops-access-request	21.4
+plugins/email-notifications	0.0
+plugins/notification	0.0
+plugins/webhook-notifications	0.0

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -95,6 +95,27 @@ go test ./pkg/recording/ -bench=. -benchtime=200ms
 
 Target is higher package coverage over time; new packages should bring tests. Lab depth: [E2E_TEST_PLAN.md](E2E_TEST_PLAN.md). Before a release: [RELEASE_SMOKE.md](RELEASE_SMOKE.md) / `make release-smoke` ([V1_RELEASE_CRITERIA.md](V1_RELEASE_CRITERIA.md)).
 
+### Coverage ratchet
+
+We are raising unit coverage toward ~80%, one package per PR. `coverage-baseline.txt`
+records what each package currently achieves, and CI fails if any package drops
+below its recorded value — it does **not** require 80% everywhere today.
+
+```bash
+make coverage-check         # what CI runs: fail on any per-package regression
+make coverage-baseline      # re-record after adding tests, then commit the diff
+```
+
+Raising one package is a good first contribution — pick one with a low number in
+`coverage-baseline.txt` (`pkg/database`, `pkg/agent`, and `pkg/client` are the
+largest gaps) and work through it. Two things we ask for:
+
+* **Cover branches, not lines.** Exercise error paths, boundaries, and the
+  behaviour a comment claims — not just the happy path taken for the percentage.
+* **Don't pad.** Error returns that are unreachable by construction (for example
+  `aes.NewCipher` on an already-validated 32-byte key) are fine to leave
+  uncovered. A package sitting below 100% for that reason is expected.
+
 ### Packages & labs
 
 ```bash

--- a/pkg/api/terminal_test.go
+++ b/pkg/api/terminal_test.go
@@ -20,7 +20,10 @@ func TestShellQuoteNeutralizesShellMetacharacters(t *testing.T) {
 	}
 	for _, path := range dangerous {
 		quoted := shellQuote(path)
-		cmd := exec.Command("/bin/sh", "-c", "echo -n "+quoted)
+		// printf %s rather than `echo -n`: the -n flag is not POSIX, and the
+		// /bin/sh builtin echo on macOS (bash in POSIX mode) prints it
+		// literally instead of suppressing the trailing newline.
+		cmd := exec.Command("/bin/sh", "-c", "printf %s "+quoted)
 		out, err := cmd.Output()
 		if err != nil {
 			t.Fatalf("shellQuote(%q) produced invalid shell syntax: %v", path, err)

--- a/pkg/authz/model_test.go
+++ b/pkg/authz/model_test.go
@@ -1,0 +1,98 @@
+package authz
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteExampleModelWritesNormalizedDSL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "model.fga")
+
+	if err := WriteExampleModel(path); err != nil {
+		t.Fatalf("WriteExampleModel: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(raw)
+
+	if strings.HasPrefix(got, "\n") {
+		t.Error("written DSL starts with a blank line, want the leading whitespace trimmed")
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Error("written DSL has no trailing newline")
+	}
+	if strings.HasSuffix(got, "\n\n") {
+		t.Error("written DSL ends with a blank line, want exactly one trailing newline")
+	}
+
+	// The relation the client defaults to must actually exist in the model it
+	// tells operators to install, or every Check fails at runtime.
+	for _, want := range []string{"model", "schema 1.1", "type user", "type machine", "can_access"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("written DSL is missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteExampleModelIsReadableByOthers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "model.fga")
+
+	if err := WriteExampleModel(path); err != nil {
+		t.Fatalf("WriteExampleModel: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	// 0644: operator-facing documentation, not a secret.
+	if perm := info.Mode().Perm(); perm != 0644 {
+		t.Errorf("permissions = %04o, want 0644", perm)
+	}
+}
+
+func TestWriteExampleModelOverwritesExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "model.fga")
+	if err := os.WriteFile(path, []byte("stale contents that must not survive"), 0644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	if err := WriteExampleModel(path); err != nil {
+		t.Fatalf("WriteExampleModel: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(raw), "stale contents") {
+		t.Error("previous file contents survived the overwrite")
+	}
+}
+
+func TestWriteExampleModelReportsUnwritablePath(t *testing.T) {
+	// A path under a file (not a directory) can never be created.
+	dir := t.TempDir()
+	notADir := filepath.Join(dir, "regular-file")
+	if err := os.WriteFile(notADir, []byte("x"), 0644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	if err := WriteExampleModel(filepath.Join(notADir, "model.fga")); err == nil {
+		t.Error("WriteExampleModel succeeded on an unwritable path, want an error")
+	}
+}
+
+func TestErrNotConfiguredIsStable(t *testing.T) {
+	if ErrNotConfigured == nil {
+		t.Fatal("ErrNotConfigured is nil")
+	}
+	if !strings.Contains(ErrNotConfigured.Error(), "openfga") {
+		t.Errorf("ErrNotConfigured = %q, want it to mention openfga", ErrNotConfigured)
+	}
+}

--- a/pkg/authz/openfga_test.go
+++ b/pkg/authz/openfga_test.go
@@ -1,0 +1,473 @@
+package authz
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/zrougamed/orion-belt/pkg/common"
+)
+
+// capture records what the fake OpenFGA server received so tests can assert on
+// the wire format — the tuple shape is the contract with OpenFGA, and a typo in
+// a key name fails open (or closed) at runtime rather than at compile time.
+type capture struct {
+	path   string
+	auth   string
+	ctype  string
+	body   map[string]interface{}
+	called int
+}
+
+func newFakeFGA(t *testing.T, status int, response string) (*httptest.Server, *capture) {
+	t.Helper()
+	cap := &capture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.called++
+		cap.path = r.URL.Path
+		cap.auth = r.Header.Get("Authorization")
+		cap.ctype = r.Header.Get("Content-Type")
+
+		raw, _ := io.ReadAll(r.Body)
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &cap.body); err != nil {
+				t.Errorf("server received non-JSON body %q: %v", raw, err)
+			}
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		w.WriteHeader(status)
+		io.WriteString(w, response)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, cap
+}
+
+func enabledConfig(url string) common.OpenFGAConfig {
+	return common.OpenFGAConfig{
+		Enabled: true,
+		APIURL:  url,
+		StoreID: "store-1",
+	}
+}
+
+func mustClient(t *testing.T, cfg common.OpenFGAConfig) *OpenFGA {
+	t.Helper()
+	o, err := NewOpenFGA(cfg, nil)
+	if err != nil {
+		t.Fatalf("NewOpenFGA: %v", err)
+	}
+	if o == nil {
+		t.Fatal("NewOpenFGA returned a nil client for an enabled config")
+	}
+	return o
+}
+
+// tupleKey digs the tuple out of a Check request body.
+func tupleKey(t *testing.T, body map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	tk, ok := body["tuple_key"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("body has no tuple_key object: %#v", body)
+	}
+	return tk
+}
+
+// firstWriteTuple digs the single tuple out of a write/delete request body.
+func firstWriteTuple(t *testing.T, body map[string]interface{}, section string) map[string]interface{} {
+	t.Helper()
+	sec, ok := body[section].(map[string]interface{})
+	if !ok {
+		t.Fatalf("body has no %q object: %#v", section, body)
+	}
+	keys, ok := sec["tuple_keys"].([]interface{})
+	if !ok || len(keys) != 1 {
+		t.Fatalf("%s.tuple_keys is not a 1-element array: %#v", section, sec)
+	}
+	tuple, ok := keys[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("%s.tuple_keys[0] is not an object: %#v", section, keys[0])
+	}
+	return tuple
+}
+
+// --- construction -----------------------------------------------------------
+
+// A disabled config yields (nil, nil) rather than an error: callers store the
+// result and treat a nil Authorizer as "authorization not in use".
+func TestNewOpenFGADisabledReturnsNilClientAndNoError(t *testing.T) {
+	o, err := NewOpenFGA(common.OpenFGAConfig{Enabled: false}, nil)
+	if err != nil {
+		t.Fatalf("NewOpenFGA(disabled) returned error %v, want nil", err)
+	}
+	if o != nil {
+		t.Error("NewOpenFGA(disabled) returned a client, want nil")
+	}
+}
+
+// Disabled wins over incomplete settings — a half-filled but switched-off block
+// must not break startup.
+func TestNewOpenFGADisabledIgnoresMissingFields(t *testing.T) {
+	o, err := NewOpenFGA(common.OpenFGAConfig{Enabled: false, APIURL: "", StoreID: ""}, nil)
+	if err != nil || o != nil {
+		t.Errorf("NewOpenFGA(disabled, empty) = (%v, %v), want (nil, nil)", o, err)
+	}
+}
+
+func TestNewOpenFGAEnabledRequiresAPIURLAndStoreID(t *testing.T) {
+	cases := map[string]common.OpenFGAConfig{
+		"missing api_url":  {Enabled: true, StoreID: "store-1"},
+		"missing store_id": {Enabled: true, APIURL: "http://fga.local"},
+		"missing both":     {Enabled: true},
+	}
+	for name, cfg := range cases {
+		t.Run(name, func(t *testing.T) {
+			o, err := NewOpenFGA(cfg, nil)
+			if err == nil {
+				t.Fatal("NewOpenFGA succeeded, want a configuration error")
+			}
+			if o != nil {
+				t.Error("NewOpenFGA returned a client alongside an error, want nil")
+			}
+		})
+	}
+}
+
+func TestNewOpenFGADefaultsRelationToCanAccess(t *testing.T) {
+	o := mustClient(t, enabledConfig("http://fga.local"))
+	if o.relation != "can_access" {
+		t.Errorf("relation = %q, want the %q default", o.relation, "can_access")
+	}
+}
+
+func TestNewOpenFGAHonoursExplicitRelation(t *testing.T) {
+	cfg := enabledConfig("http://fga.local")
+	cfg.Relation = "viewer"
+
+	if o := mustClient(t, cfg); o.relation != "viewer" {
+		t.Errorf("relation = %q, want %q", o.relation, "viewer")
+	}
+}
+
+// The API URL is concatenated with paths that already begin with "/", so a
+// configured trailing slash would produce "//stores/...".
+func TestNewOpenFGATrimsTrailingSlashFromAPIURL(t *testing.T) {
+	o := mustClient(t, enabledConfig("http://fga.local/"))
+	if o.apiURL != "http://fga.local" {
+		t.Errorf("apiURL = %q, want the trailing slash trimmed", o.apiURL)
+	}
+}
+
+// --- Check ------------------------------------------------------------------
+
+func TestCheckReturnsAllowedDecision(t *testing.T) {
+	for _, allowed := range []bool{true, false} {
+		t.Run(map[bool]string{true: "allowed", false: "denied"}[allowed], func(t *testing.T) {
+			body := `{"allowed":false}`
+			if allowed {
+				body = `{"allowed":true}`
+			}
+			srv, _ := newFakeFGA(t, http.StatusOK, body)
+
+			got, err := mustClient(t, enabledConfig(srv.URL)).Check(context.Background(), "u1", "m1", "ssh")
+			if err != nil {
+				t.Fatalf("Check: %v", err)
+			}
+			if got != allowed {
+				t.Errorf("Check = %v, want %v", got, allowed)
+			}
+		})
+	}
+}
+
+// An OpenFGA response that omits "allowed" must deny, not default to true.
+func TestCheckDeniesWhenResponseOmitsAllowed(t *testing.T) {
+	srv, _ := newFakeFGA(t, http.StatusOK, `{}`)
+
+	got, err := mustClient(t, enabledConfig(srv.URL)).Check(context.Background(), "u1", "m1", "ssh")
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if got {
+		t.Error("Check = true for a response without an \"allowed\" field, want false")
+	}
+}
+
+func TestCheckSendsCorrectPathAndTuple(t *testing.T) {
+	srv, cap := newFakeFGA(t, http.StatusOK, `{"allowed":true}`)
+
+	cfg := enabledConfig(srv.URL)
+	cfg.StoreID = "store-xyz"
+	if _, err := mustClient(t, cfg).Check(context.Background(), "alice", "web-01", "ssh"); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+
+	if want := "/stores/store-xyz/check"; cap.path != want {
+		t.Errorf("path = %q, want %q", cap.path, want)
+	}
+	if cap.ctype != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", cap.ctype)
+	}
+
+	tk := tupleKey(t, cap.body)
+	for key, want := range map[string]string{
+		"user":     "user:alice",
+		"relation": "can_access",
+		"object":   "machine:web-01",
+	} {
+		if got := tk[key]; got != want {
+			t.Errorf("tuple_key[%q] = %v, want %q", key, got, want)
+		}
+	}
+}
+
+func TestCheckForwardsAccessTypeAsContext(t *testing.T) {
+	srv, cap := newFakeFGA(t, http.StatusOK, `{"allowed":true}`)
+
+	if _, err := mustClient(t, enabledConfig(srv.URL)).Check(context.Background(), "u1", "m1", "sftp"); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+
+	ctx, ok := cap.body["context"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("body has no context object: %#v", cap.body)
+	}
+	if got := ctx["access_type"]; got != "sftp" {
+		t.Errorf("context.access_type = %v, want %q", got, "sftp")
+	}
+}
+
+// --- authorization model id --------------------------------------------------
+
+func TestModelIDIncludedOnlyWhenConfigured(t *testing.T) {
+	t.Run("omitted when empty", func(t *testing.T) {
+		srv, cap := newFakeFGA(t, http.StatusOK, `{"allowed":true}`)
+
+		if _, err := mustClient(t, enabledConfig(srv.URL)).Check(context.Background(), "u", "m", "ssh"); err != nil {
+			t.Fatalf("Check: %v", err)
+		}
+		if _, present := cap.body["authorization_model_id"]; present {
+			t.Error("authorization_model_id was sent despite no model id being configured")
+		}
+	})
+
+	t.Run("sent when configured", func(t *testing.T) {
+		srv, cap := newFakeFGA(t, http.StatusOK, `{"allowed":true}`)
+		cfg := enabledConfig(srv.URL)
+		cfg.ModelID = "model-42"
+
+		if _, err := mustClient(t, cfg).Check(context.Background(), "u", "m", "ssh"); err != nil {
+			t.Fatalf("Check: %v", err)
+		}
+		if got := cap.body["authorization_model_id"]; got != "model-42" {
+			t.Errorf("authorization_model_id = %v, want %q", got, "model-42")
+		}
+	})
+}
+
+// --- WriteGrant / DeleteGrant ------------------------------------------------
+
+// Both grant operations hit the same /write endpoint and are distinguished
+// only by the "writes" vs "deletes" section — swapping them would silently
+// invert the effect of an access grant.
+func TestWriteGrantSendsWritesSection(t *testing.T) {
+	srv, cap := newFakeFGA(t, http.StatusOK, `{}`)
+
+	if err := mustClient(t, enabledConfig(srv.URL)).WriteGrant(context.Background(), "bob", "db-02", "ssh"); err != nil {
+		t.Fatalf("WriteGrant: %v", err)
+	}
+
+	if want := "/stores/store-1/write"; cap.path != want {
+		t.Errorf("path = %q, want %q", cap.path, want)
+	}
+	if _, present := cap.body["deletes"]; present {
+		t.Error("WriteGrant sent a \"deletes\" section")
+	}
+
+	tuple := firstWriteTuple(t, cap.body, "writes")
+	if tuple["user"] != "user:bob" || tuple["object"] != "machine:db-02" || tuple["relation"] != "can_access" {
+		t.Errorf("write tuple = %#v, want user:bob / can_access / machine:db-02", tuple)
+	}
+}
+
+func TestDeleteGrantSendsDeletesSection(t *testing.T) {
+	srv, cap := newFakeFGA(t, http.StatusOK, `{}`)
+
+	if err := mustClient(t, enabledConfig(srv.URL)).DeleteGrant(context.Background(), "bob", "db-02", "ssh"); err != nil {
+		t.Fatalf("DeleteGrant: %v", err)
+	}
+
+	if want := "/stores/store-1/write"; cap.path != want {
+		t.Errorf("path = %q, want %q", cap.path, want)
+	}
+	if _, present := cap.body["writes"]; present {
+		t.Error("DeleteGrant sent a \"writes\" section")
+	}
+
+	tuple := firstWriteTuple(t, cap.body, "deletes")
+	if tuple["user"] != "user:bob" || tuple["object"] != "machine:db-02" {
+		t.Errorf("delete tuple = %#v, want user:bob / machine:db-02", tuple)
+	}
+}
+
+func TestGrantsUseConfiguredRelation(t *testing.T) {
+	srv, cap := newFakeFGA(t, http.StatusOK, `{}`)
+	cfg := enabledConfig(srv.URL)
+	cfg.Relation = "viewer"
+
+	if err := mustClient(t, cfg).WriteGrant(context.Background(), "u", "m", "ssh"); err != nil {
+		t.Fatalf("WriteGrant: %v", err)
+	}
+	if got := firstWriteTuple(t, cap.body, "writes")["relation"]; got != "viewer" {
+		t.Errorf("relation = %v, want %q", got, "viewer")
+	}
+}
+
+func TestModelIDIncludedOnGrants(t *testing.T) {
+	cfg := func(url string) common.OpenFGAConfig {
+		c := enabledConfig(url)
+		c.ModelID = "model-7"
+		return c
+	}
+
+	t.Run("write", func(t *testing.T) {
+		srv, cap := newFakeFGA(t, http.StatusOK, `{}`)
+		if err := mustClient(t, cfg(srv.URL)).WriteGrant(context.Background(), "u", "m", "ssh"); err != nil {
+			t.Fatalf("WriteGrant: %v", err)
+		}
+		if got := cap.body["authorization_model_id"]; got != "model-7" {
+			t.Errorf("authorization_model_id = %v, want %q", got, "model-7")
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		srv, cap := newFakeFGA(t, http.StatusOK, `{}`)
+		if err := mustClient(t, cfg(srv.URL)).DeleteGrant(context.Background(), "u", "m", "ssh"); err != nil {
+			t.Fatalf("DeleteGrant: %v", err)
+		}
+		if got := cap.body["authorization_model_id"]; got != "model-7" {
+			t.Errorf("authorization_model_id = %v, want %q", got, "model-7")
+		}
+	})
+}
+
+// --- auth header -------------------------------------------------------------
+
+func TestAPITokenSentAsBearerWhenConfigured(t *testing.T) {
+	srv, cap := newFakeFGA(t, http.StatusOK, `{"allowed":true}`)
+	cfg := enabledConfig(srv.URL)
+	cfg.APIToken = "s3cret"
+
+	if _, err := mustClient(t, cfg).Check(context.Background(), "u", "m", "ssh"); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if want := "Bearer s3cret"; cap.auth != want {
+		t.Errorf("Authorization = %q, want %q", cap.auth, want)
+	}
+}
+
+func TestNoAuthHeaderWhenTokenUnset(t *testing.T) {
+	srv, cap := newFakeFGA(t, http.StatusOK, `{"allowed":true}`)
+
+	if _, err := mustClient(t, enabledConfig(srv.URL)).Check(context.Background(), "u", "m", "ssh"); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if cap.auth != "" {
+		t.Errorf("Authorization = %q, want it unset", cap.auth)
+	}
+}
+
+// --- error paths --------------------------------------------------------------
+
+// A non-2xx must surface as an error and never as a silent "allowed=false",
+// so an OpenFGA outage is visibly broken rather than quietly denying everyone.
+func TestCheckSurfacesNon2xxAsError(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			srv, _ := newFakeFGA(t, status, `{"code":"boom","message":"upstream failed"}`)
+
+			allowed, err := mustClient(t, enabledConfig(srv.URL)).Check(context.Background(), "u", "m", "ssh")
+			if err == nil {
+				t.Fatal("Check succeeded on an error status, want an error")
+			}
+			if allowed {
+				t.Error("Check = true alongside an error, want false")
+			}
+			// The upstream body is the only diagnostic an operator gets.
+			if !strings.Contains(err.Error(), "upstream failed") {
+				t.Errorf("error = %v, want it to include the upstream response body", err)
+			}
+		})
+	}
+}
+
+func TestGrantsSurfaceNon2xxAsError(t *testing.T) {
+	t.Run("write", func(t *testing.T) {
+		srv, _ := newFakeFGA(t, http.StatusInternalServerError, `nope`)
+		if err := mustClient(t, enabledConfig(srv.URL)).WriteGrant(context.Background(), "u", "m", "ssh"); err == nil {
+			t.Error("WriteGrant succeeded on a 500, want an error")
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		srv, _ := newFakeFGA(t, http.StatusInternalServerError, `nope`)
+		if err := mustClient(t, enabledConfig(srv.URL)).DeleteGrant(context.Background(), "u", "m", "ssh"); err == nil {
+			t.Error("DeleteGrant succeeded on a 500, want an error")
+		}
+	})
+}
+
+func TestCheckFailsOnMalformedJSONResponse(t *testing.T) {
+	srv, _ := newFakeFGA(t, http.StatusOK, `{"allowed":`)
+
+	if _, err := mustClient(t, enabledConfig(srv.URL)).Check(context.Background(), "u", "m", "ssh"); err == nil {
+		t.Error("Check succeeded on a truncated JSON body, want a decode error")
+	}
+}
+
+// A 2xx with an empty body is fine for the grant calls, which pass out == nil.
+func TestGrantsAcceptEmptySuccessBody(t *testing.T) {
+	srv, _ := newFakeFGA(t, http.StatusOK, ``)
+
+	if err := mustClient(t, enabledConfig(srv.URL)).WriteGrant(context.Background(), "u", "m", "ssh"); err != nil {
+		t.Errorf("WriteGrant on an empty 200 body: %v", err)
+	}
+}
+
+func TestCheckFailsWhenServerUnreachable(t *testing.T) {
+	srv, _ := newFakeFGA(t, http.StatusOK, `{"allowed":true}`)
+	url := srv.URL
+	srv.Close() // nothing is listening now
+
+	o := mustClient(t, enabledConfig(url))
+	if _, err := o.Check(context.Background(), "u", "m", "ssh"); err == nil {
+		t.Fatal("Check succeeded against a closed server, want a transport error")
+	} else if !strings.Contains(err.Error(), "openfga request") {
+		t.Errorf("error = %v, want it wrapped as an openfga request failure", err)
+	}
+}
+
+func TestCheckHonoursCancelledContext(t *testing.T) {
+	srv, cap := newFakeFGA(t, http.StatusOK, `{"allowed":true}`)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before the call
+
+	if _, err := mustClient(t, enabledConfig(srv.URL)).Check(ctx, "u", "m", "ssh"); err == nil {
+		t.Error("Check succeeded with a cancelled context, want an error")
+	}
+	if cap.called != 0 {
+		t.Errorf("server was called %d times despite a cancelled context, want 0", cap.called)
+	}
+}
+
+// --- interface conformance ----------------------------------------------------
+
+func TestOpenFGASatisfiesAuthorizer(t *testing.T) {
+	var _ Authorizer = (*OpenFGA)(nil)
+}

--- a/pkg/cryptutil/envelope_test.go
+++ b/pkg/cryptutil/envelope_test.go
@@ -1,0 +1,272 @@
+package cryptutil
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func mustEnvelope(t *testing.T, material string) *Envelope {
+	t.Helper()
+	e, err := NewEnvelope(material)
+	if err != nil {
+		t.Fatalf("NewEnvelope(%q): %v", material, err)
+	}
+	return e
+}
+
+// --- key derivation ---------------------------------------------------------
+
+// deriveKey has three branches whose precedence matters: a 32-byte base64
+// payload wins over a 32-character literal, which wins over the SHA-256
+// passphrase fallback. Getting that order wrong silently changes the key for
+// existing deployments, so pin each branch.
+func TestDeriveKeyBranches(t *testing.T) {
+	raw32 := bytes.Repeat([]byte{0xAB}, 32)
+	b64 := base64.StdEncoding.EncodeToString(raw32)
+
+	t.Run("base64 of exactly 32 bytes is decoded", func(t *testing.T) {
+		key, err := deriveKey(b64)
+		if err != nil {
+			t.Fatalf("deriveKey: %v", err)
+		}
+		if !bytes.Equal(key, raw32) {
+			t.Errorf("deriveKey(base64) = %x, want the decoded bytes %x", key, raw32)
+		}
+	})
+
+	t.Run("literal 32-byte string is used verbatim", func(t *testing.T) {
+		// Not valid base64, so the first branch cannot claim it.
+		material := strings.Repeat("!", 32)
+		key, err := deriveKey(material)
+		if err != nil {
+			t.Fatalf("deriveKey: %v", err)
+		}
+		if !bytes.Equal(key, []byte(material)) {
+			t.Errorf("deriveKey(literal) = %x, want %x", key, []byte(material))
+		}
+	})
+
+	t.Run("base64 decoding to a non-32-byte payload falls through", func(t *testing.T) {
+		// 32 base64 chars decode to 24 bytes, so the base64 branch must not
+		// claim this; the 32-char literal branch should.
+		material := strings.Repeat("A", 32)
+		if decoded, err := base64.StdEncoding.DecodeString(material); err != nil || len(decoded) == 32 {
+			t.Fatalf("test premise broken: decoded %d bytes, err=%v", len(decoded), err)
+		}
+		key, err := deriveKey(material)
+		if err != nil {
+			t.Fatalf("deriveKey: %v", err)
+		}
+		if !bytes.Equal(key, []byte(material)) {
+			t.Errorf("deriveKey = %x, want the literal bytes %x", key, []byte(material))
+		}
+	})
+
+	t.Run("arbitrary passphrase is hashed to 32 bytes", func(t *testing.T) {
+		key, err := deriveKey("a short passphrase")
+		if err != nil {
+			t.Fatalf("deriveKey: %v", err)
+		}
+		if len(key) != 32 {
+			t.Errorf("deriveKey(passphrase) length = %d, want 32", len(key))
+		}
+	})
+}
+
+func TestDeriveKeyIsDeterministicAndDistinct(t *testing.T) {
+	a1, _ := deriveKey("passphrase-one")
+	a2, _ := deriveKey("passphrase-one")
+	b, _ := deriveKey("passphrase-two")
+
+	if !bytes.Equal(a1, a2) {
+		t.Error("deriveKey is not deterministic for identical material")
+	}
+	if bytes.Equal(a1, b) {
+		t.Error("distinct passphrases derived the same key")
+	}
+}
+
+// --- enabled / disabled state ----------------------------------------------
+
+func TestEnvelopeDisabledWhenKeyMaterialBlank(t *testing.T) {
+	for _, material := range []string{"", "   ", "\t\n "} {
+		e := mustEnvelope(t, material)
+		if e.Enabled() {
+			t.Errorf("NewEnvelope(%q).Enabled() = true, want false", material)
+		}
+	}
+}
+
+func TestEnvelopeEnabledWithKeyMaterial(t *testing.T) {
+	if !mustEnvelope(t, "some passphrase").Enabled() {
+		t.Error("Enabled() = false for a configured envelope, want true")
+	}
+}
+
+// Enabled() guards on a nil receiver so callers holding an optional *Envelope
+// can ask without a nil check.
+func TestNilEnvelopeIsNotEnabled(t *testing.T) {
+	var e *Envelope
+	if e.Enabled() {
+		t.Error("(*Envelope)(nil).Enabled() = true, want false")
+	}
+}
+
+// --- round trip -------------------------------------------------------------
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	e := mustEnvelope(t, "correct horse battery staple")
+
+	cases := map[string][]byte{
+		"empty":  {},
+		"short":  []byte("hello"),
+		"binary": {0x00, 0xFF, 0x00, 0x10, 0x80},
+		"large":  bytes.Repeat([]byte("session-recording-frame;"), 4096),
+	}
+
+	for name, plain := range cases {
+		t.Run(name, func(t *testing.T) {
+			sealed, err := e.Encrypt(plain)
+			if err != nil {
+				t.Fatalf("Encrypt: %v", err)
+			}
+			opened, err := e.Decrypt(sealed)
+			if err != nil {
+				t.Fatalf("Decrypt: %v", err)
+			}
+			if !bytes.Equal(opened, plain) {
+				t.Errorf("round trip changed the payload: got %d bytes, want %d", len(opened), len(plain))
+			}
+		})
+	}
+}
+
+func TestEncryptEmitsMagicPrefixAndHidesPlaintext(t *testing.T) {
+	e := mustEnvelope(t, "key material")
+	plain := []byte("super secret value")
+
+	sealed, err := e.Encrypt(plain)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if !bytes.HasPrefix(sealed, []byte(envelopeMagic)) {
+		t.Errorf("sealed output %q lacks the envelope magic prefix", sealed[:min(len(sealed), 16)])
+	}
+	if bytes.Contains(sealed, plain) {
+		t.Error("sealed output still contains the plaintext")
+	}
+}
+
+// A fresh nonce per call is what keeps AES-GCM safe across repeated writes of
+// the same recording frame; identical output for identical input would be a
+// key-recovery-grade bug.
+func TestEncryptUsesFreshNoncePerCall(t *testing.T) {
+	e := mustEnvelope(t, "key material")
+	plain := []byte("identical plaintext")
+
+	first, err := e.Encrypt(plain)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	second, err := e.Encrypt(plain)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if bytes.Equal(first, second) {
+		t.Error("two Encrypt calls on the same plaintext produced identical ciphertext; nonce is being reused")
+	}
+}
+
+// --- disabled-envelope pass-through ----------------------------------------
+
+func TestDisabledEnvelopePassesDataThrough(t *testing.T) {
+	e := mustEnvelope(t, "")
+	plain := []byte("not encrypted at all")
+
+	sealed, err := e.Encrypt(plain)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if !bytes.Equal(sealed, plain) {
+		t.Errorf("disabled Encrypt = %q, want the input unchanged", sealed)
+	}
+
+	opened, err := e.Decrypt(plain)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if !bytes.Equal(opened, plain) {
+		t.Errorf("disabled Decrypt = %q, want the input unchanged", opened)
+	}
+}
+
+// Recordings written before encryption was switched on have no magic prefix
+// and must keep opening cleanly even on a configured envelope.
+func TestDecryptPassesThroughLegacyPlaintext(t *testing.T) {
+	e := mustEnvelope(t, "key material")
+	legacy := []byte("plaintext written before encryption was enabled")
+
+	opened, err := e.Decrypt(legacy)
+	if err != nil {
+		t.Fatalf("Decrypt(legacy): %v", err)
+	}
+	if !bytes.Equal(opened, legacy) {
+		t.Errorf("Decrypt(legacy) = %q, want the input unchanged", opened)
+	}
+}
+
+// --- failure paths ----------------------------------------------------------
+
+func TestDecryptEncryptedDataWithoutKeyFails(t *testing.T) {
+	sealed, err := mustEnvelope(t, "key material").Encrypt([]byte("secret"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	if _, err := mustEnvelope(t, "").Decrypt(sealed); err == nil {
+		t.Fatal("Decrypt of sealed data on a disabled envelope succeeded, want an error")
+	} else if !strings.Contains(err.Error(), "no key is configured") {
+		t.Errorf("error = %v, want it to mention the missing key", err)
+	}
+}
+
+func TestDecryptRejectsTruncatedCiphertext(t *testing.T) {
+	e := mustEnvelope(t, "key material")
+
+	// Magic present but the nonce is incomplete.
+	truncated := append([]byte(envelopeMagic), 0x01, 0x02, 0x03)
+	if _, err := e.Decrypt(truncated); err == nil {
+		t.Fatal("Decrypt of truncated ciphertext succeeded, want an error")
+	} else if !strings.Contains(err.Error(), "too short") {
+		t.Errorf("error = %v, want a 'too short' error", err)
+	}
+}
+
+func TestDecryptRejectsTamperedCiphertext(t *testing.T) {
+	e := mustEnvelope(t, "key material")
+	sealed, err := e.Encrypt([]byte("integrity protected payload"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	// Flip a bit in the final ciphertext byte; GCM's tag must reject it.
+	tampered := bytes.Clone(sealed)
+	tampered[len(tampered)-1] ^= 0x01
+
+	if _, err := e.Decrypt(tampered); err == nil {
+		t.Error("Decrypt of tampered ciphertext succeeded, want an authentication failure")
+	}
+}
+
+func TestDecryptWithWrongKeyFails(t *testing.T) {
+	sealed, err := mustEnvelope(t, "the right key").Encrypt([]byte("secret"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	if _, err := mustEnvelope(t, "the wrong key").Decrypt(sealed); err == nil {
+		t.Error("Decrypt with the wrong key succeeded, want an authentication failure")
+	}
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,283 @@
+package metrics
+
+import (
+	"bufio"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// scrape renders the collector through its handler and returns the exposition
+// text plus a metric-name -> value index of the sample lines.
+func scrape(t *testing.T, c *Collector) (string, map[string]string) {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	c.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	samples := map[string]string{}
+	sc := bufio.NewScanner(strings.NewReader(body))
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		name, value, ok := strings.Cut(line, " ")
+		if !ok {
+			t.Errorf("malformed sample line %q", line)
+			continue
+		}
+		if _, dup := samples[name]; dup {
+			t.Errorf("metric %q exposed more than once", name)
+		}
+		samples[name] = value
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scanning body: %v", err)
+	}
+	return body, samples
+}
+
+func wantSample(t *testing.T, samples map[string]string, name, want string) {
+	t.Helper()
+	got, ok := samples[name]
+	if !ok {
+		t.Errorf("metric %q is missing from the exposition", name)
+		return
+	}
+	if got != want {
+		t.Errorf("%s = %s, want %s", name, got, want)
+	}
+}
+
+func TestNewStartsAtZero(t *testing.T) {
+	_, samples := scrape(t, New())
+
+	for _, name := range []string{
+		"orion_belt_ssh_sessions_total",
+		"orion_belt_ssh_sessions_active",
+		"orion_belt_api_requests_total",
+		"orion_belt_auth_failures_total",
+		"orion_belt_access_requests_total",
+		"orion_belt_agents_connected",
+	} {
+		wantSample(t, samples, name, "0")
+	}
+}
+
+func TestDefaultCollectorIsUsable(t *testing.T) {
+	if Default == nil {
+		t.Fatal("Default collector is nil")
+	}
+	// Exercised via the package-level singleton the server actually uses.
+	before := Default.APIRequestsTotal.Load()
+	Default.IncAPIRequest()
+	if got := Default.APIRequestsTotal.Load(); got != before+1 {
+		t.Errorf("Default.APIRequestsTotal = %d, want %d", got, before+1)
+	}
+}
+
+func TestHandlerSetsPrometheusContentType(t *testing.T) {
+	rec := httptest.NewRecorder()
+	New().Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	// Prometheus needs the version parameter to pick the text parser.
+	if got, want := rec.Header().Get("Content-Type"), "text/plain; version=0.0.4; charset=utf-8"; got != want {
+		t.Errorf("Content-Type = %q, want %q", got, want)
+	}
+}
+
+// Every series needs its HELP and TYPE metadata, and the TYPE must match the
+// semantics — a counter exposed as a gauge breaks rate() queries downstream.
+func TestExpositionDeclaresHelpAndType(t *testing.T) {
+	body, _ := scrape(t, New())
+
+	wantTypes := map[string]string{
+		"orion_belt_up":                    "gauge",
+		"orion_belt_uptime_seconds":        "gauge",
+		"orion_belt_ssh_sessions_total":    "counter",
+		"orion_belt_ssh_sessions_active":   "gauge",
+		"orion_belt_api_requests_total":    "counter",
+		"orion_belt_auth_failures_total":   "counter",
+		"orion_belt_access_requests_total": "counter",
+		"orion_belt_agents_connected":      "gauge",
+	}
+	for name, typ := range wantTypes {
+		if !strings.Contains(body, "# HELP "+name+" ") {
+			t.Errorf("missing HELP line for %q", name)
+		}
+		if want := "# TYPE " + name + " " + typ; !strings.Contains(body, want) {
+			t.Errorf("missing or wrong TYPE line for %q, want %q", name, want)
+		}
+	}
+}
+
+func TestUpIsAlwaysOne(t *testing.T) {
+	_, samples := scrape(t, New())
+	wantSample(t, samples, "orion_belt_up", "1")
+}
+
+func TestUptimeIsNonNegativeAndGrows(t *testing.T) {
+	c := New()
+
+	_, samples := scrape(t, c)
+	raw, ok := samples["orion_belt_uptime_seconds"]
+	if !ok {
+		t.Fatal("orion_belt_uptime_seconds is missing")
+	}
+	// Rendered with %.0f, so it must parse as a plain integer-valued float.
+	if _, err := strconv.ParseFloat(raw, 64); err != nil {
+		t.Fatalf("uptime %q is not a number: %v", raw, err)
+	}
+
+	// Backdating the start time is the only way to observe growth without
+	// making the test sleep for a second.
+	c.startTime = time.Now().Add(-90 * time.Second)
+	_, samples = scrape(t, c)
+	if got := samples["orion_belt_uptime_seconds"]; got != "90" {
+		t.Errorf("uptime after backdating 90s = %s, want 90", got)
+	}
+}
+
+func TestCounterIncrements(t *testing.T) {
+	cases := []struct {
+		name   string
+		metric string
+		inc    func(*Collector)
+		times  int
+	}{
+		{"api requests", "orion_belt_api_requests_total", (*Collector).IncAPIRequest, 3},
+		{"auth failures", "orion_belt_auth_failures_total", (*Collector).IncAuthFailure, 2},
+		{"access requests", "orion_belt_access_requests_total", (*Collector).IncAccessRequest, 5},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New()
+			for i := 0; i < tc.times; i++ {
+				tc.inc(c)
+			}
+			_, samples := scrape(t, c)
+			wantSample(t, samples, tc.metric, strconv.Itoa(tc.times))
+		})
+	}
+}
+
+// SessionStarted bumps both the lifetime counter and the active gauge, but
+// SessionEnded must only decrement the gauge — decrementing the counter too
+// would make the total non-monotonic.
+func TestSessionLifecycleTracksTotalAndActiveSeparately(t *testing.T) {
+	c := New()
+
+	c.SessionStarted()
+	c.SessionStarted()
+	c.SessionStarted()
+
+	_, samples := scrape(t, c)
+	wantSample(t, samples, "orion_belt_ssh_sessions_total", "3")
+	wantSample(t, samples, "orion_belt_ssh_sessions_active", "3")
+
+	c.SessionEnded()
+	c.SessionEnded()
+
+	_, samples = scrape(t, c)
+	wantSample(t, samples, "orion_belt_ssh_sessions_total", "3") // unchanged
+	wantSample(t, samples, "orion_belt_ssh_sessions_active", "1")
+}
+
+// The active gauge is signed, so an unbalanced SessionEnded shows up as a
+// negative value rather than wrapping to a huge number.
+func TestUnbalancedSessionEndedGoesNegative(t *testing.T) {
+	c := New()
+	c.SessionEnded()
+
+	_, samples := scrape(t, c)
+	wantSample(t, samples, "orion_belt_ssh_sessions_active", "-1")
+}
+
+func TestSetAgentsConnectedReplacesRatherThanAccumulates(t *testing.T) {
+	c := New()
+
+	c.SetAgentsConnected(7)
+	_, samples := scrape(t, c)
+	wantSample(t, samples, "orion_belt_agents_connected", "7")
+
+	c.SetAgentsConnected(2)
+	_, samples = scrape(t, c)
+	wantSample(t, samples, "orion_belt_agents_connected", "2")
+
+	c.SetAgentsConnected(0)
+	_, samples = scrape(t, c)
+	wantSample(t, samples, "orion_belt_agents_connected", "0")
+}
+
+// The collector is process-wide and written from every request goroutine, so
+// the atomics have to hold up under -race.
+func TestConcurrentUpdatesAreRaceFree(t *testing.T) {
+	c := New()
+
+	const goroutines, perGoroutine = 16, 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				c.IncAPIRequest()
+				c.IncAuthFailure()
+				c.IncAccessRequest()
+				c.SessionStarted()
+				c.SessionEnded()
+			}
+		}()
+	}
+	wg.Wait()
+
+	want := strconv.Itoa(goroutines * perGoroutine)
+	_, samples := scrape(t, c)
+	wantSample(t, samples, "orion_belt_api_requests_total", want)
+	wantSample(t, samples, "orion_belt_auth_failures_total", want)
+	wantSample(t, samples, "orion_belt_access_requests_total", want)
+	wantSample(t, samples, "orion_belt_ssh_sessions_total", want)
+	wantSample(t, samples, "orion_belt_ssh_sessions_active", "0") // balanced
+}
+
+// Scraping concurrently with updates is the normal production pattern.
+func TestHandlerIsSafeDuringConcurrentUpdates(t *testing.T) {
+	c := New()
+	done := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				c.IncAPIRequest()
+			}
+		}
+	}()
+
+	for i := 0; i < 50; i++ {
+		rec := httptest.NewRecorder()
+		c.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d during concurrent updates, want 200", rec.Code)
+		}
+	}
+
+	close(done)
+	wg.Wait()
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,102 @@
+package version
+
+import "testing"
+
+// The build vars are package-level and set via -ldflags, so tests must restore
+// them or they leak into every later test in the package.
+func withBuildInfo(t *testing.T, version, commit, date string) {
+	t.Helper()
+	oldV, oldC, oldD := Version, Commit, Date
+	t.Cleanup(func() { Version, Commit, Date = oldV, oldC, oldD })
+	Version, Commit, Date = version, commit, date
+}
+
+func TestStringOmitsCommitWhenUnset(t *testing.T) {
+	// "none" is the compiled-in default when -ldflags didn't supply a commit;
+	// both it and the empty string mean "no commit to show".
+	for _, commit := range []string{"", "none"} {
+		t.Run("commit="+commit, func(t *testing.T) {
+			withBuildInfo(t, "1.2.3", commit, "2026-07-28")
+			if got := String(); got != "1.2.3" {
+				t.Errorf("String() = %q, want %q", got, "1.2.3")
+			}
+		})
+	}
+}
+
+func TestStringTruncatesLongCommitToShortSHA(t *testing.T) {
+	withBuildInfo(t, "1.2.3", "abcdef1234567890abcdef1234567890abcdef12", "2026-07-28")
+
+	if got, want := String(), "1.2.3+abcdef12"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestStringKeepsShortCommitIntact(t *testing.T) {
+	// Exactly 8 characters is the boundary: it must not be truncated further.
+	withBuildInfo(t, "1.2.3", "abcdef12", "2026-07-28")
+	if got, want := String(), "1.2.3+abcdef12"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+
+	// Fewer than 8 characters passes through unchanged rather than panicking
+	// on the slice bound.
+	withBuildInfo(t, "1.2.3", "abc", "2026-07-28")
+	if got, want := String(), "1.2.3+abc"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultBuildInfoIsUsableWithoutLdflags(t *testing.T) {
+	// An un-stamped `go build` must still produce something printable rather
+	// than an empty version string.
+	if String() == "" {
+		t.Error("String() is empty for the default build vars")
+	}
+}
+
+func TestInfoReportsAllFieldsIncludingDisplay(t *testing.T) {
+	withBuildInfo(t, "2.0.0", "0123456789abcdef", "2026-07-28")
+
+	info := Info()
+	want := map[string]string{
+		"version": "2.0.0",
+		"commit":  "0123456789abcdef",
+		"date":    "2026-07-28",
+		"display": "2.0.0+01234567",
+	}
+	if len(info) != len(want) {
+		t.Errorf("Info() has %d keys (%v), want %d", len(info), info, len(want))
+	}
+	for k, v := range want {
+		if got := info[k]; got != v {
+			t.Errorf("Info()[%q] = %q, want %q", k, got, v)
+		}
+	}
+}
+
+// Info() must report the untruncated commit but the truncated display string;
+// conflating the two would lose information in the API response.
+func TestInfoKeepsFullCommitButShortDisplay(t *testing.T) {
+	full := "abcdef1234567890abcdef1234567890abcdef12"
+	withBuildInfo(t, "1.0.0", full, "2026-07-28")
+
+	info := Info()
+	if info["commit"] != full {
+		t.Errorf("Info()[\"commit\"] = %q, want the full SHA %q", info["commit"], full)
+	}
+	if info["display"] != "1.0.0+abcdef12" {
+		t.Errorf("Info()[\"display\"] = %q, want the short form", info["display"])
+	}
+}
+
+func TestInfoReturnsIndependentMaps(t *testing.T) {
+	// Callers serialize this straight to JSON; a shared map would let one
+	// handler's mutation bleed into another's response.
+	a, b := Info(), Info()
+	a["version"] = "mutated"
+
+	if b["version"] == "mutated" {
+		t.Error("Info() returned a shared map; mutating one result affected another")
+	}
+}

--- a/scripts/coverage-check.sh
+++ b/scripts/coverage-check.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Per-package coverage ratchet.
+#
+# Coverage is being raised toward ~80% incrementally, one package per PR. This
+# gate does not demand 80% everywhere today — it only forbids sliding backwards
+# from whatever each package has already earned, recorded in coverage-baseline.txt.
+#
+#   scripts/coverage-check.sh            # verify no package regressed
+#   scripts/coverage-check.sh --update   # re-record the baseline after adding tests
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+BASELINE="coverage-baseline.txt"
+PROFILE="${COVERAGE_PROFILE:-coverage.out}"
+# Coverage percentages are deterministic for a given source tree, but allow a
+# hair of slack so a statement-count rounding shift can't fail an unrelated PR.
+TOLERANCE="${COVERAGE_TOLERANCE:-0.5}"
+
+UPDATE=0
+[[ "${1:-}" == "--update" ]] && UPDATE=1
+
+CUR="$(mktemp)"
+RAW="$(mktemp)"
+trap 'rm -f "$CUR" "$RAW"' EXIT
+
+echo "==> Running tests with coverage"
+go test ./pkg/... ./plugins/... -coverprofile="$PROFILE" -covermode=atomic | tee "$RAW"
+
+# `go test -cover` prints one authoritative line per package. Shapes:
+#   ok  \tPKG\t0.66s\tcoverage: 3.8% of statements     -> has tests
+#       \tPKG\t\tcoverage: 0.0% of statements          -> compiles, no tests
+#   ok  \tPKG\t0.30s\tcoverage: [no statements]        -> nothing to measure, skip
+#   ?   \tPKG\t[no test files]                         -> skip
+awk '{
+  pct = ""
+  for (i = 1; i <= NF; i++) {
+    if ($i == "coverage:") { pct = $(i + 1); break }
+  }
+  sub(/%$/, "", pct)
+  if (pct !~ /^[0-9.]+$/) next
+  pkg = ($1 == "ok") ? $2 : $1
+  # Dynamic (string) regex: BSD awk mis-parses "/" inside a bracket
+  # expression in a /.../ literal.
+  sub("^github\\.com/[^/]+/[^/]+/", "", pkg)
+  printf "%s\t%s\n", pkg, pct
+}' "$RAW" | sort > "$CUR"
+
+if [[ ! -s "$CUR" ]]; then
+  echo "error: no coverage data produced" >&2
+  exit 1
+fi
+
+if [[ $UPDATE -eq 1 ]]; then
+  {
+    echo "# Per-package statement coverage baseline for the coverage ratchet."
+    echo "# Regenerate with: scripts/coverage-check.sh --update"
+    echo "# A package may never drop below its recorded value; raising it is the goal (~80%)."
+    cat "$CUR"
+  } > "$BASELINE"
+  echo "==> Baseline written to $BASELINE"
+  sed 's/^/    /' "$CUR"
+  exit 0
+fi
+
+if [[ ! -f "$BASELINE" ]]; then
+  echo "error: $BASELINE missing; create it with scripts/coverage-check.sh --update" >&2
+  exit 1
+fi
+
+echo
+echo "==> Comparing against $BASELINE (tolerance ${TOLERANCE}pp)"
+fail=0
+gained=0
+
+while IFS=$'\t' read -r pkg cur; do
+  base="$(awk -F'\t' -v p="$pkg" '$1 == p { print $2 }' "$BASELINE")"
+  if [[ -z "$base" ]]; then
+    printf '    %-50s %6s%%  (new package, not yet in baseline)\n' "$pkg" "$cur"
+    gained=1
+    continue
+  fi
+  if awk -v c="$cur" -v b="$base" -v t="$TOLERANCE" 'BEGIN { exit !(c < b - t) }'; then
+    printf '  x %-50s %6s%%  REGRESSED from %s%%\n' "$pkg" "$cur" "$base"
+    fail=1
+  elif awk -v c="$cur" -v b="$base" -v t="$TOLERANCE" 'BEGIN { exit !(c > b + t) }'; then
+    printf '  + %-50s %6s%%  up from %s%%\n' "$pkg" "$cur" "$base"
+    gained=1
+  fi
+done < "$CUR"
+
+if [[ $fail -eq 1 ]]; then
+  echo
+  echo "Coverage regressed. Add tests for the affected package, or if the drop is"
+  echo "intentional (e.g. covered code was deleted), re-record with:"
+  echo "    scripts/coverage-check.sh --update"
+  exit 1
+fi
+
+if [[ $gained -eq 1 ]]; then
+  echo
+  echo "Coverage improved — commit the new baseline:"
+  echo "    scripts/coverage-check.sh --update"
+else
+  echo "    (no change)"
+fi
+
+echo "==> No package regressed"


### PR DESCRIPTION
Description: 
Raises unit test coverage toward ~80% across the codebase. This is naturally splittable by package, making it a good ongoing entry point for contributors who want to get familiar with one part of the codebase (pkg/agent, pkg/api, pkg/plugin, etc.) at a time.

Issue:
#72