### PR TITLE
FR-8.9: add gateway performance benchmark suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
         run: go test ./pkg/... ./e2e/...
         env:
           ORION_CVE_E2E: "1"
+      # One iteration of every benchmark: too few to time anything, enough to
+      # catch a benchmark that no longer builds or panics. The timing gate runs
+      # nightly in perf.yml, where the runner noise matters less.
+      - name: Benchmark smoke test
+        run: go test ./pkg/... -run '^$' -bench . -benchtime=1x
 
   coverage:
     name: Coverage ratchet

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,91 @@
+name: Performance benchmarks
+
+# Benchmarks run on a schedule rather than on every PR. GitHub's hosted runners
+# are shared and noisy, so per-PR timing gates fail on unrelated changes; a
+# nightly run against master gives a clean signal and a history to look back
+# through. Use workflow_dispatch to check a branch by hand before merging
+# something performance-sensitive.
+on:
+  schedule:
+    # 03:17 UTC daily — off the hour, where scheduled-job contention is worst.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+    inputs:
+      update_baseline:
+        description: 'Re-record perf-baseline.txt from this run instead of gating against it'
+        type: boolean
+        default: false
+      benchtime:
+        description: 'Iterations per benchmark (Go -benchtime)'
+        type: string
+        default: '1000x'
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: Gateway benchmarks
+    runs-on: ubuntu-latest
+    # The suite is a few minutes; cap it so a hung benchmark cannot burn an
+    # hour of runner time every night.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run benchmarks and check for regressions
+        id: perf
+        env:
+          PERF_BENCHTIME: ${{ inputs.benchtime || '1000x' }}
+          PERF_RAW_OUTPUT: bench-raw.txt
+        run: |
+          if [ "${{ inputs.update_baseline }}" = "true" ]; then
+            bash scripts/perf-check.sh --update
+          else
+            bash scripts/perf-check.sh
+          fi
+
+      # Results tracked over time: every run's raw numbers are retained as an
+      # artifact, and the committed baseline's git history is the long-term
+      # record of where performance has moved.
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ github.run_number }}
+          path: |
+            bench-raw.txt
+            perf-baseline.txt
+          retention-days: 90
+
+      - name: Publish results to the run summary
+        if: always()
+        run: |
+          {
+            echo "## Gateway benchmark results"
+            echo
+            echo "Commit \`${GITHUB_SHA::8}\` · benchtime \`${{ inputs.benchtime || '1000x' }}\`"
+            echo
+            echo '```'
+            grep '^Benchmark' bench-raw.txt || echo '(no benchmark output captured)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # When run with update_baseline, the new baseline has to be committed by
+      # hand: this workflow deliberately holds no write permission, so a perf
+      # regression can never quietly re-baseline itself away.
+      - name: Remind about the updated baseline
+        if: inputs.update_baseline == true
+        run: |
+          {
+            echo
+            echo "### Baseline updated"
+            echo
+            echo "Download the \`benchmark-results-${{ github.run_number }}\` artifact and commit"
+            echo "its \`perf-baseline.txt\`, noting in the commit message why the numbers moved."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ bin/
 *.out
 coverage.out
 
+# Raw benchmark output (scripts/perf-check.sh); perf-baseline.txt IS tracked
+bench-raw.txt
+
 # Go workspace file
 go.work
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: build build-server build-client build-agent build-ui test clean install \
         test-coverage coverage-check coverage-baseline \
+        bench perf-check perf-baseline \
         docker-build docker-build-server docker-build-agent docker-build-client \
         docker-push docker-up docker-down docker-logs docker-agent-up docker-agent-down \
         cve packages repos packaging-key sign-artifacts lab-compose-up lab-compose-down lab-bootstrap-admin \
@@ -108,6 +109,21 @@ coverage-check:
 # Re-record coverage-baseline.txt after adding tests
 coverage-baseline:
 	bash scripts/coverage-check.sh --update
+
+# Run the gateway performance benchmarks once and print the results.
+# For a quick local look; the gate below is what CI runs. See docs/BENCHMARKS.md.
+bench:
+	$(GO) test ./pkg/... -run '^$$' -bench . -benchmem -benchtime=1000x
+
+# Fail if a benchmark regressed beyond tolerance vs perf-baseline.txt
+perf-check:
+	bash scripts/perf-check.sh
+
+# Re-record perf-baseline.txt. Baselines are machine-specific: the committed
+# one comes from the CI runner, so prefer the "Performance benchmarks" workflow
+# with update_baseline=true over running this locally.
+perf-baseline:
+	bash scripts/perf-check.sh --update
 
 # Format code
 fmt:

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ make build   # Go 1.26.5+ (see go.mod)
 | [openssh-clients.md](docs/openssh-clients.md) | Vanilla `ssh` via the gateway |
 | [DEPLOYMENT_HARDENING.md](docs/DEPLOYMENT_HARDENING.md) | Hardening checklist |
 | [OBSERVABILITY.md](docs/OBSERVABILITY.md) | Metrics + logging |
+| [BENCHMARKS.md](docs/BENCHMARKS.md) | Session/throughput benchmarks + perf gate |
 | [OpenAPI](docs/openapi/openapi.yaml) | HTTP/WS API |
 | [ROADMAP.md](docs/ROADMAP.md) | What’s next (OIDC, HA, …) |
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,152 @@
+# Performance benchmarks
+
+A repeatable benchmark suite for the two things that make a gateway feel slow:
+how long it takes to establish a session, and how fast it moves bytes once one
+is established. It runs nightly in CI so regressions surface in a build rather
+than in someone's terminal.
+
+- Benchmarks: [`pkg/server/bench_test.go`](../pkg/server/bench_test.go)
+- Gate: [`scripts/perf-check.sh`](../scripts/perf-check.sh)
+- Baseline: [`perf-baseline.txt`](../perf-baseline.txt)
+- Workflow: [`.github/workflows/perf.yml`](../.github/workflows/perf.yml)
+
+## Running them
+
+```bash
+make bench          # run once, print results
+make perf-check     # run and fail if anything regressed vs the baseline
+make perf-baseline  # re-record the baseline (see "Updating the baseline")
+```
+
+To dig into one benchmark:
+
+```bash
+go test ./pkg/server/ -run '^$' -bench BenchmarkSessionEstablish -benchmem -benchtime=1000x
+```
+
+## What is measured
+
+Everything runs against the in-memory `fakeStore` over loopback TCP. There is
+no Postgres and no real network in the numbers, which is the point: a movement
+here means our code changed, not that the database or the runner's network did.
+
+### Control plane — session establishment
+
+`BenchmarkSessionEstablish` measures one full session establishment, serially:
+TCP connect, SSH handshake, and public-key/certificate authentication —
+everything between "user runs `ssh`" and "the connection is authenticated". It
+covers all three credential types the gateway accepts, because they do
+materially different work:
+
+| Sub-benchmark   | Path                                                        |
+| --------------- | ----------------------------------------------------------- |
+| `legacy_pubkey` | Static authorized-key lookup — the pre-SSH-CA path           |
+| `user_cert`     | User-CA certificate validation — the SSH CA client path      |
+| `host_cert`     | Host-CA certificate validation — the reverse-dial agent path |
+
+`ns/op` is end-to-end latency for one session. `allocs/op` and `B/op` matter
+just as much: they are deterministic, so they catch a regression long before it
+is visible in wall-clock time on a noisy runner.
+
+### Control plane — establishment under concurrent load
+
+`BenchmarkSessionEstablishUnderLoad` runs the same establishment with a fixed
+number of clients connecting at once (8, 32, 64), and reports:
+
+- `sessions/s` — authenticated sessions completed per second, the headline
+  throughput number
+- `p50-ms`, `p95-ms`, `p99-ms` — the latency spread across those sessions
+
+Concurrency is a fixed worker count rather than `b.RunParallel`'s
+GOMAXPROCS-scaled parallelism, so `clients_32` means 32 clients on a 4-core
+runner and on a 16-core laptop alike. Without that, baselines would not be
+comparable across machines.
+
+### Data plane — proxied throughput
+
+`BenchmarkGatewayProxyThroughput` measures agent→client bytes per second
+through `proxyConnection`, with and without session recording:
+
+- `proxy_only` — the bare copy loop
+- `recorded` — the same, with a `SessionRecorder` in the path
+
+The `MB/s` figure is **not** an achievable wire throughput: reads come from
+memory and writes go to `io.Discard`, so the SSH transport's own encryption and
+windowing are deliberately excluded. It is an upper bound that isolates the
+gateway's per-byte overhead, and the gap between the two variants is what the
+recording layer costs every byte a user sees. On current code, recording is
+the dominant data-plane cost by a wide margin — worth remembering before
+attributing a slow session to the network.
+
+## The regression gate
+
+`scripts/perf-check.sh` runs the suite, reduces each metric to its **best of N**
+runs, and compares against `perf-baseline.txt`. Best-of-N rather than the mean
+because noise only ever makes a benchmark slower, never faster, so the minimum
+is the closest thing to a clean measurement a shared runner can give.
+
+Metrics gate at two different tolerances, because they are not equally noisy:
+
+| Metric group                              | Tolerance | Why                                                                                                     |
+| ----------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------- |
+| `B/op`, `allocs/op`                       | 5%        | Deterministic for a given source tree. This is where subtle regressions actually get caught.              |
+| `ns/op`, `p50-ms`, `sessions/s`, `MB/s`   | 50%       | Measured run-to-run spread on an idle machine reaches ~19%; 50% leaves headroom for a busy shared runner. |
+| `p95-ms`, `p99-ms`                        | not gated | Tails of a bounded sample; swung 17–26% between back-to-back local runs. Recorded for trends only.        |
+
+Tunable via `PERF_ALLOC_TOLERANCE`, `PERF_TIME_TOLERANCE`, `PERF_UNGATED_METRICS`,
+`PERF_BENCHTIME`, `PERF_COUNT`, `PERF_PACKAGES`, `PERF_BASELINE`.
+
+## When it runs
+
+- **Every PR** ([`ci.yml`](../.github/workflows/ci.yml)) — one iteration of every
+  benchmark (`-benchtime=1x`). Far too few to time anything; enough to catch a
+  benchmark that no longer builds or that panics. No timing gate, so a busy
+  runner cannot fail an unrelated PR.
+- **Nightly at 03:17 UTC** ([`perf.yml`](../.github/workflows/perf.yml)) — the full
+  suite with the regression gate.
+- **On demand** — `workflow_dispatch` on `perf.yml`, to check a branch before
+  merging something performance-sensitive.
+
+## Results over time
+
+Each nightly run uploads `bench-raw.txt` and the baseline as a
+`benchmark-results-<run>` artifact (90-day retention) and prints the benchmark
+lines to the run summary, so any run's numbers are readable without downloading
+anything. The long-term record is `perf-baseline.txt`'s git history — each
+commit to it marks a point where performance moved and says why.
+
+## Updating the baseline
+
+The committed baseline is **seeded with allocation metrics only**. `B/op` and
+`allocs/op` are properties of the source tree rather than the machine (they
+drift <0.02% run to run), so they gate correctly anywhere. Timing metrics are
+machine-specific, and seeding them from a laptop would have failed on the first
+CI run — so they are absent, reported as "new, not in baseline", and pass.
+
+To bring the timing gate live, record it on the runner:
+
+1. Run the **Performance benchmarks** workflow with `update_baseline=true`.
+2. Download the `benchmark-results-<run>` artifact.
+3. Commit its `perf-baseline.txt`, saying in the commit message why the numbers
+   moved.
+
+The workflow holds no write permission and will not commit for you — a
+regression should never be able to quietly re-baseline itself away.
+
+The same steps apply later whenever a change legitimately moves the numbers.
+Baselines recorded on a different machine than the runner will not compare
+meaningfully, so avoid committing a locally generated one.
+
+## Adding a benchmark
+
+New benchmarks are reported as "new, not in baseline" and are not gated until
+the baseline is re-recorded. Two things to keep in mind:
+
+- **Discard log output.** Use `benchLogger()` (`common.NewLoggerTo(level,
+  io.Discard)`) rather than `common.NewLogger`. Log lines on stdout corrupt the
+  gate's parsing, and stdout I/O would be charged to the measurement — while
+  discarding still keeps the log *formatting* cost in it, which is where the
+  real work is.
+- **Fix your own concurrency.** Prefer an explicit worker count over
+  `b.RunParallel` for anything load-related, so the number means the same thing
+  on every machine.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -116,6 +116,22 @@ largest gaps) and work through it. Two things we ask for:
   `aes.NewCipher` on an already-validated 32-byte key) are fine to leave
   uncovered. A package sitting below 100% for that reason is expected.
 
+### Performance benchmarks
+
+Session establishment and gateway throughput are benchmarked, gated against
+`perf-baseline.txt`, and run nightly. Every PR runs one iteration of each
+benchmark to catch breakage, but timing is only gated nightly — a busy shared
+runner can't fail your PR.
+
+```bash
+make bench          # run once, print results
+make perf-check     # what the nightly job runs: fail on regression
+```
+
+Worth running locally before merging anything on the auth or proxy path. Full
+details — what's measured, the tolerances, how to re-record the baseline — in
+[BENCHMARKS.md](BENCHMARKS.md).
+
 ### Packages & labs
 
 ```bash

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -295,7 +295,7 @@ Notes: [V1_RELEASE_CRITERIA.md](V1_RELEASE_CRITERIA.md), [API_STABILITY.md](API_
 - [ ] Integration test suites
 - [x] End-to-end CVE gate (`e2e/cve`, `scripts/cve-check.sh`)
 - [x] Multi-distro e2e lab (compose + QEMU) + [E2E test plan](E2E_TEST_PLAN.md)
-- [ ] Performance benchmarks
+- [x] Performance benchmarks (`pkg/server/bench_test.go`, nightly gate) — [BENCHMARKS.md](BENCHMARKS.md)
 - [x] Architecture Decision Records (ADRs) — started (`docs/adr/`)
 
 **Refactoring**

--- a/perf-baseline.txt
+++ b/perf-baseline.txt
@@ -1,0 +1,48 @@
+# Gateway performance baseline for scripts/perf-check.sh.
+# Format: benchmark<TAB>metric<TAB>best-of-N value.
+#
+# Seeded with allocation metrics only, on purpose.
+#
+# B/op and allocs/op are properties of the source tree, not of the machine —
+# they drift <0.02% between runs — so they gate meaningfully (5%) no matter
+# where the suite runs, and they catch the subtle regressions first.
+#
+# Timing metrics (ns/op, p50-ms, sessions/s, MB/s) are machine-dependent, and
+# these numbers would have come from a laptop. Rather than commit values that
+# would immediately fail on a CI runner, they are left out: perf-check.sh
+# reports them as "new, not in baseline" and passes. Record them on the runner
+# via the "Performance benchmarks" workflow (workflow_dispatch,
+# update_baseline=true) and commit the result — after that, the timing gate is
+# live too and this header can go.
+#
+# See docs/BENCHMARKS.md.
+BenchmarkGatewayProxyThroughput/proxy_only	B/op	65920
+BenchmarkGatewayProxyThroughput/proxy_only	allocs/op	9
+BenchmarkGatewayProxyThroughput/recorded	B/op	1496861
+BenchmarkGatewayProxyThroughput/recorded	allocs/op	66
+BenchmarkMaybeCompressGzip	B/op	814642
+BenchmarkMaybeCompressGzip	allocs/op	21
+BenchmarkSessionEstablish/host_cert	B/op	113149
+BenchmarkSessionEstablish/host_cert	allocs/op	816
+BenchmarkSessionEstablish/legacy_pubkey	B/op	98143
+BenchmarkSessionEstablish/legacy_pubkey	allocs/op	682
+BenchmarkSessionEstablish/user_cert	B/op	119372
+BenchmarkSessionEstablish/user_cert	allocs/op	874
+BenchmarkSessionEstablishUnderLoad/host_cert/clients_32	B/op	113206
+BenchmarkSessionEstablishUnderLoad/host_cert/clients_32	allocs/op	816
+BenchmarkSessionEstablishUnderLoad/host_cert/clients_64	B/op	113227
+BenchmarkSessionEstablishUnderLoad/host_cert/clients_64	allocs/op	816
+BenchmarkSessionEstablishUnderLoad/host_cert/clients_8	B/op	113171
+BenchmarkSessionEstablishUnderLoad/host_cert/clients_8	allocs/op	816
+BenchmarkSessionEstablishUnderLoad/legacy_pubkey/clients_32	B/op	98324
+BenchmarkSessionEstablishUnderLoad/legacy_pubkey/clients_32	allocs/op	683
+BenchmarkSessionEstablishUnderLoad/legacy_pubkey/clients_64	B/op	98240
+BenchmarkSessionEstablishUnderLoad/legacy_pubkey/clients_64	allocs/op	683
+BenchmarkSessionEstablishUnderLoad/legacy_pubkey/clients_8	B/op	98186
+BenchmarkSessionEstablishUnderLoad/legacy_pubkey/clients_8	allocs/op	682
+BenchmarkSessionEstablishUnderLoad/user_cert/clients_32	B/op	119427
+BenchmarkSessionEstablishUnderLoad/user_cert/clients_32	allocs/op	874
+BenchmarkSessionEstablishUnderLoad/user_cert/clients_64	B/op	119446
+BenchmarkSessionEstablishUnderLoad/user_cert/clients_64	allocs/op	874
+BenchmarkSessionEstablishUnderLoad/user_cert/clients_8	B/op	119388
+BenchmarkSessionEstablishUnderLoad/user_cert/clients_8	allocs/op	874

--- a/pkg/common/logger.go
+++ b/pkg/common/logger.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -28,8 +29,16 @@ type Logger struct {
 
 // NewLogger creates a JSON logger writing to stdout.
 func NewLogger(level LogLevel) *Logger {
+	return NewLoggerTo(level, os.Stdout)
+}
+
+// NewLoggerTo creates a JSON logger writing to w. Useful when log output must
+// not land on stdout — benchmarks discard it so log lines neither pollute
+// machine-readable results nor charge stdout I/O to the measurement, while the
+// formatting cost stays in it.
+func NewLoggerTo(level LogLevel, w io.Writer) *Logger {
 	opts := &slog.HandlerOptions{Level: slogLevel(level)}
-	h := slog.NewJSONHandler(os.Stdout, opts)
+	h := slog.NewJSONHandler(w, opts)
 	return &Logger{
 		level:  level,
 		logger: slog.New(h),

--- a/pkg/server/bench_test.go
+++ b/pkg/server/bench_test.go
@@ -1,0 +1,461 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/zrougamed/orion-belt/pkg/auth"
+	"github.com/zrougamed/orion-belt/pkg/ca"
+	"github.com/zrougamed/orion-belt/pkg/common"
+	"github.com/zrougamed/orion-belt/pkg/plugin"
+	"github.com/zrougamed/orion-belt/pkg/recording"
+)
+
+// Gateway performance benchmarks.
+//
+// Two things are measured, matching the two ways the gateway can get slow:
+//
+//   - Control plane — session establishment: TCP connect + SSH handshake +
+//     publickey/certificate auth, i.e. everything between "user runs ssh" and
+//     "the connection is authenticated". This is the latency a user feels on
+//     every new session, and it is dominated by code we own (cert validation,
+//     CA checks, store lookups) plus the crypto handshake.
+//
+//   - Data plane — proxied bytes: the client<->agent copy loop, with and
+//     without session recording in the path. This is what determines whether
+//     an interactive session feels responsive under output-heavy commands.
+//
+// Everything runs against the in-memory fakeStore over loopback TCP, so there
+// is no Postgres or network variance in the numbers: a change here means a
+// change in our code. See docs/BENCHMARKS.md.
+
+// -----------------------------------------------------------------------------
+// Control plane: session establishment
+// -----------------------------------------------------------------------------
+
+// benchLogger logs at the gateway's normal level but discards the output, so
+// per-call log formatting is still charged to the benchmark while the results
+// on stdout stay parseable.
+func benchLogger() *common.Logger {
+	return common.NewLoggerTo(common.INFO, io.Discard)
+}
+
+// benchGateway is a running SSH gateway listener wired to the real
+// handlePublicKeyAuth dispatch, so each dial exercises the production auth
+// path rather than an in-process function call.
+type benchGateway struct {
+	srv      *Server
+	listener net.Listener
+	wg       sync.WaitGroup
+}
+
+func newBenchGateway(tb testing.TB, store *fakeStore) (*benchGateway, *ca.Authority) {
+	tb.Helper()
+
+	srv, authority := testServerWithLogger(tb, store, benchLogger())
+	// testServer leaves authService nil (its tests only exercise the cert
+	// paths); the legacy static-pubkey benchmark needs it.
+	srv.authService = auth.NewAuthService(store, srv.logger)
+	srv.pluginManager = plugin.NewManager(srv.logger)
+
+	hostSigner, _ := genKey(tb)
+	cfg := &ssh.ServerConfig{PublicKeyCallback: srv.handlePublicKeyAuth}
+	cfg.AddHostKey(hostSigner)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatalf("listen: %v", err)
+	}
+
+	g := &benchGateway{srv: srv, listener: listener}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.wg.Done()
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			discardTimeWait(conn)
+			g.wg.Add(1)
+			go func() {
+				defer g.wg.Done()
+				defer conn.Close()
+				sshConn, chans, reqs, err := ssh.NewServerConn(conn, cfg)
+				if err != nil {
+					return
+				}
+				defer sshConn.Close()
+				go ssh.DiscardRequests(reqs)
+				for nc := range chans {
+					_ = nc.Reject(ssh.UnknownChannelType, "benchmark gateway")
+				}
+			}()
+		}
+	}()
+
+	// Closing the listener unblocks Accept and ends the accept loop; the
+	// per-connection goroutines end when their client disconnects.
+	tb.Cleanup(func() {
+		listener.Close()
+		g.wg.Wait()
+	})
+
+	return g, authority
+}
+
+// discardTimeWait makes Close send RST instead of FIN, so the socket is
+// released immediately rather than sitting in TIME_WAIT.
+//
+// These benchmarks open tens of thousands of short-lived loopback connections.
+// With a normal close, every one of them holds an ephemeral port for the
+// TIME_WAIT interval (30-120s depending on the OS), the ~16k-port range is
+// exhausted within a run, and dials start failing with "can't assign requested
+// address" — which is a property of the measurement harness, not of the
+// gateway. Load generators drop TIME_WAIT for exactly this reason. It affects
+// only how the connection is torn down, not the establishment being measured.
+func discardTimeWait(conn net.Conn) {
+	if tcp, ok := conn.(*net.TCPConn); ok {
+		_ = tcp.SetLinger(0)
+	}
+}
+
+// establish performs one full session establishment and tears it down.
+// Dialling is done by hand rather than via ssh.Dial so the TCP connection can
+// be configured before the SSH handshake runs on top of it.
+func (g *benchGateway) establish(sshUser string, signer ssh.Signer) error {
+	addr := g.listener.Addr().String()
+
+	conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	if err != nil {
+		return err
+	}
+	discardTimeWait(conn)
+
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, &ssh.ClientConfig{
+		User:            sshUser,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Second,
+	})
+	if err != nil {
+		conn.Close()
+		return err
+	}
+
+	return ssh.NewClient(sshConn, chans, reqs).Close()
+}
+
+// benchIdentity is one authenticated principal the gateway will accept.
+type benchIdentity struct {
+	sshUser string
+	signer  ssh.Signer
+}
+
+// legacyPubkeyIdentity registers a user whose static public key is the
+// credential — the pre-SSH-CA path most deployments still use.
+func legacyPubkeyIdentity(tb testing.TB, store *fakeStore) benchIdentity {
+	tb.Helper()
+	signer, pub := genKey(tb)
+	user := common.NewUser("bench-user", "bench@example.com", "", false)
+	user.PublicKey = string(ssh.MarshalAuthorizedKey(pub))
+	if err := store.CreateUser(context.Background(), user); err != nil {
+		tb.Fatalf("CreateUser: %v", err)
+	}
+	return benchIdentity{sshUser: user.Username, signer: signer}
+}
+
+// userCertIdentity registers a user and issues them a short-lived User-CA
+// certificate — the SSH CA client path.
+func userCertIdentity(tb testing.TB, store *fakeStore, authority *ca.Authority) benchIdentity {
+	tb.Helper()
+	key, pub := genKey(tb)
+	user := common.NewUser("bench-cert-user", "bench-cert@example.com", "", false)
+	if err := store.CreateUser(context.Background(), user); err != nil {
+		tb.Fatalf("CreateUser: %v", err)
+	}
+	cert, err := authority.IssueUserCert(context.Background(), user.ID, user.Username, pub, 0)
+	if err != nil {
+		tb.Fatalf("IssueUserCert: %v", err)
+	}
+	return benchIdentity{sshUser: user.Username, signer: mustCertSigner(tb, cert, key)}
+}
+
+// hostCertIdentity registers a machine and issues its agent a Host-CA
+// certificate — the reverse-dial agent path.
+func hostCertIdentity(tb testing.TB, store *fakeStore, authority *ca.Authority) benchIdentity {
+	tb.Helper()
+	key, pub := genKey(tb)
+	machine := common.NewMachine("bench-host-01", "10.0.0.5", 22, nil)
+	if err := store.CreateMachine(context.Background(), machine); err != nil {
+		tb.Fatalf("CreateMachine: %v", err)
+	}
+	cert, err := authority.IssueHostCert(context.Background(), machine.ID, []string{machine.Name}, pub, 0)
+	if err != nil {
+		tb.Fatalf("IssueHostCert: %v", err)
+	}
+	return benchIdentity{sshUser: machine.Name, signer: mustCertSigner(tb, cert, key)}
+}
+
+// benchAuthPaths returns, per credential type the gateway accepts, a setup
+// function that builds a gateway already primed to authenticate it. Setup is
+// deferred rather than done eagerly because Go re-invokes a benchmark body as
+// it ramps b.N, and each invocation needs its own gateway.
+func benchAuthPaths() map[string]func(testing.TB) (*benchGateway, benchIdentity) {
+	return map[string]func(testing.TB) (*benchGateway, benchIdentity){
+		"legacy_pubkey": func(tb testing.TB) (*benchGateway, benchIdentity) {
+			store := newFakeStore()
+			g, _ := newBenchGateway(tb, store)
+			return g, legacyPubkeyIdentity(tb, store)
+		},
+		"user_cert": func(tb testing.TB) (*benchGateway, benchIdentity) {
+			store := newFakeStore()
+			g, authority := newBenchGateway(tb, store)
+			return g, userCertIdentity(tb, store, authority)
+		},
+		"host_cert": func(tb testing.TB) (*benchGateway, benchIdentity) {
+			store := newFakeStore()
+			g, authority := newBenchGateway(tb, store)
+			return g, hostCertIdentity(tb, store, authority)
+		},
+	}
+}
+
+// benchAuthPathNames keeps sub-benchmark ordering stable across runs so the
+// baseline file diffs cleanly.
+var benchAuthPathNames = []string{"legacy_pubkey", "user_cert", "host_cert"}
+
+// BenchmarkSessionEstablish measures single-session establishment latency for
+// each credential type: ns/op is the end-to-end cost of one authenticated
+// session, serially, with no contention.
+func BenchmarkSessionEstablish(b *testing.B) {
+	paths := benchAuthPaths()
+	for _, name := range benchAuthPathNames {
+		b.Run(name, func(b *testing.B) {
+			g, id := paths[name](b)
+
+			// Warm up: the first handshake pays one-time costs (CA key
+			// decrypt, revocation list load) that would otherwise skew a
+			// short run.
+			if err := g.establish(id.sshUser, id.signer); err != nil {
+				b.Fatalf("warmup establish: %v", err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := g.establish(id.sshUser, id.signer); err != nil {
+					b.Fatalf("establish: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSessionEstablishUnderLoad measures establishment throughput and
+// latency spread with a fixed number of clients connecting concurrently.
+//
+// Concurrency is a fixed worker count rather than b.RunParallel's
+// GOMAXPROCS-scaled parallelism, so the same numbers mean the same thing on a
+// 4-core CI runner and a 16-core laptop — a prerequisite for comparing runs
+// over time.
+func BenchmarkSessionEstablishUnderLoad(b *testing.B) {
+	paths := benchAuthPaths()
+	for _, name := range benchAuthPathNames {
+		for _, workers := range []int{8, 32, 64} {
+			b.Run(fmt.Sprintf("%s/clients_%d", name, workers), func(b *testing.B) {
+				g, id := paths[name](b)
+				if err := g.establish(id.sshUser, id.signer); err != nil {
+					b.Fatalf("warmup establish: %v", err)
+				}
+				benchEstablishConcurrent(b, g, id, workers)
+			})
+		}
+	}
+}
+
+func benchEstablishConcurrent(b *testing.B, g *benchGateway, id benchIdentity, workers int) {
+	b.Helper()
+
+	remaining := int64(b.N)
+	perWorker := make([][]time.Duration, workers)
+	var failures int64
+
+	var wg sync.WaitGroup
+	b.ResetTimer()
+	start := time.Now()
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			local := make([]time.Duration, 0, b.N/workers+1)
+			for atomic.AddInt64(&remaining, -1) >= 0 {
+				t0 := time.Now()
+				err := g.establish(id.sshUser, id.signer)
+				elapsed := time.Since(t0)
+				if err != nil {
+					atomic.AddInt64(&failures, 1)
+					continue
+				}
+				local = append(local, elapsed)
+			}
+			perWorker[w] = local
+		}(w)
+	}
+	wg.Wait()
+
+	wall := time.Since(start)
+	b.StopTimer()
+
+	if n := atomic.LoadInt64(&failures); n > 0 {
+		b.Fatalf("%d/%d session establishments failed under load", n, b.N)
+	}
+
+	all := make([]time.Duration, 0, b.N)
+	for _, l := range perWorker {
+		all = append(all, l...)
+	}
+
+	// Throughput is the headline number: authenticated sessions the gateway
+	// completes per second at this concurrency.
+	b.ReportMetric(float64(len(all))/wall.Seconds(), "sessions/s")
+	b.ReportMetric(percentileMillis(all, 0.50), "p50-ms")
+	b.ReportMetric(percentileMillis(all, 0.95), "p95-ms")
+	b.ReportMetric(percentileMillis(all, 0.99), "p99-ms")
+}
+
+// percentileMillis returns the p-th percentile of d in milliseconds using
+// nearest-rank, which needs no interpolation and is stable for small samples.
+func percentileMillis(d []time.Duration, p float64) float64 {
+	if len(d) == 0 {
+		return 0
+	}
+	sorted := make([]time.Duration, len(d))
+	copy(sorted, d)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	rank := int(p*float64(len(sorted))+0.5) - 1
+	if rank < 0 {
+		rank = 0
+	}
+	if rank >= len(sorted) {
+		rank = len(sorted) - 1
+	}
+	return float64(sorted[rank].Nanoseconds()) / 1e6
+}
+
+// -----------------------------------------------------------------------------
+// Data plane: proxied session throughput
+// -----------------------------------------------------------------------------
+
+// benchChannel is a minimal ssh.Channel standing in for a real client or agent
+// channel, so proxyConnection can be measured without the SSH transport's
+// own encryption and windowing masking the gateway's per-byte overhead.
+type benchChannel struct {
+	r io.Reader
+	w io.Writer
+}
+
+func (c *benchChannel) Read(p []byte) (int, error)  { return c.r.Read(p) }
+func (c *benchChannel) Write(p []byte) (int, error) { return c.w.Write(p) }
+func (c *benchChannel) Close() error                { return nil }
+func (c *benchChannel) CloseWrite() error           { return nil }
+func (c *benchChannel) Stderr() io.ReadWriter       { return &benchChannel{r: eofReader{}, w: io.Discard} }
+
+func (c *benchChannel) SendRequest(name string, wantReply bool, payload []byte) (bool, error) {
+	return true, nil
+}
+
+type eofReader struct{}
+
+func (eofReader) Read([]byte) (int, error) { return 0, io.EOF }
+
+// proxyPayloadSize is one op's worth of agent→client output. 256 KiB is large
+// enough that per-byte costs dominate per-op setup, and is copied by io.Copy in
+// 32 KiB chunks — so each op also exercises 8 recording writes.
+const proxyPayloadSize = 256 * 1024
+
+// recordingRotateEvery bounds the in-memory cast buffer: a SessionRecorder
+// accumulates events until StopRecording flushes them, so a long run would
+// otherwise grow without limit. Rotation happens with the timer stopped.
+const recordingRotateEvery = 100
+
+// BenchmarkGatewayProxyThroughput measures agent→client bytes per second
+// through proxyConnection, with and without session recording in the path.
+// The delta between the two is the cost the recording layer adds to every
+// byte a user sees.
+func BenchmarkGatewayProxyThroughput(b *testing.B) {
+	payload := make([]byte, proxyPayloadSize)
+	for i := range payload {
+		payload[i] = byte('a' + i%26)
+	}
+
+	logger := benchLogger()
+	srv := &Server{logger: logger, config: &common.Config{}}
+
+	b.Run("proxy_only", func(b *testing.B) {
+		b.SetBytes(proxyPayloadSize)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			srv.proxyConnection(
+				&benchChannel{r: eofReader{}, w: io.Discard},
+				&benchChannel{r: bytes.NewReader(payload), w: io.Discard},
+				nil, true,
+			)
+		}
+	})
+
+	b.Run("recorded", func(b *testing.B) {
+		recorder, err := recording.NewRecorder(b.TempDir(), logger)
+		if err != nil {
+			b.Fatalf("NewRecorder: %v", err)
+		}
+
+		session := 0
+		sr := startBenchRecording(b, recorder, session)
+
+		b.SetBytes(proxyPayloadSize)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if i > 0 && i%recordingRotateEvery == 0 {
+				b.StopTimer()
+				_ = recorder.StopRecording(benchSessionID(session))
+				session++
+				sr = startBenchRecording(b, recorder, session)
+				b.StartTimer()
+			}
+			srv.proxyConnection(
+				&benchChannel{r: eofReader{}, w: io.Discard},
+				&benchChannel{r: bytes.NewReader(payload), w: io.Discard},
+				sr, true,
+			)
+		}
+		b.StopTimer()
+		_ = recorder.StopRecording(benchSessionID(session))
+	})
+}
+
+func benchSessionID(n int) string { return fmt.Sprintf("bench-session-%d", n) }
+
+func startBenchRecording(b *testing.B, recorder *recording.Recorder, n int) *recording.SessionRecorder {
+	b.Helper()
+	sr, err := recorder.StartRecording(benchSessionID(n))
+	if err != nil {
+		b.Fatalf("StartRecording: %v", err)
+	}
+	return sr
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -160,12 +160,20 @@ func (f *fakeStore) RevokeSSHCertificate(_ context.Context, serial, revokedBy, r
 	return nil
 }
 
-func testServer(t *testing.T, store *fakeStore) (*Server, *ca.Authority) {
-	t.Helper()
-	logger := common.NewLogger(common.INFO)
+// testServer builds a Server wired to the fake store. It takes testing.TB so
+// the benchmarks in bench_test.go can share the harness with the tests.
+func testServer(tb testing.TB, store *fakeStore) (*Server, *ca.Authority) {
+	tb.Helper()
+	return testServerWithLogger(tb, store, common.NewLogger(common.INFO))
+}
+
+// testServerWithLogger is testServer with the log destination chosen by the
+// caller — the benchmarks discard log output to keep their stdout parseable.
+func testServerWithLogger(tb testing.TB, store *fakeStore, logger *common.Logger) (*Server, *ca.Authority) {
+	tb.Helper()
 	authority, err := ca.New(common.SSHCAConfig{Enabled: true, MasterKey: "0123456789abcdef0123456789abcdef"}, store, logger)
 	if err != nil {
-		t.Fatalf("ca.New: %v", err)
+		tb.Fatalf("ca.New: %v", err)
 	}
 	return &Server{
 		store:         store,
@@ -176,19 +184,19 @@ func testServer(t *testing.T, store *fakeStore) (*Server, *ca.Authority) {
 	}, authority
 }
 
-func genKey(t *testing.T) (ssh.Signer, ssh.PublicKey) {
-	t.Helper()
+func genKey(tb testing.TB) (ssh.Signer, ssh.PublicKey) {
+	tb.Helper()
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
-		t.Fatalf("generate key: %v", err)
+		tb.Fatalf("generate key: %v", err)
 	}
 	signer, err := ssh.NewSignerFromKey(priv)
 	if err != nil {
-		t.Fatalf("wrap signer: %v", err)
+		tb.Fatalf("wrap signer: %v", err)
 	}
 	sshPub, err := ssh.NewPublicKey(pub)
 	if err != nil {
-		t.Fatalf("wrap pubkey: %v", err)
+		tb.Fatalf("wrap pubkey: %v", err)
 	}
 	return signer, sshPub
 }
@@ -263,11 +271,11 @@ func dialWithSigner(t *testing.T, srv *Server, sshUser string, signer ssh.Signer
 	}
 }
 
-func mustCertSigner(t *testing.T, cert *ssh.Certificate, key ssh.Signer) ssh.Signer {
-	t.Helper()
+func mustCertSigner(tb testing.TB, cert *ssh.Certificate, key ssh.Signer) ssh.Signer {
+	tb.Helper()
 	signer, err := ssh.NewCertSigner(cert, key)
 	if err != nil {
-		t.Fatalf("NewCertSigner: %v", err)
+		tb.Fatalf("NewCertSigner: %v", err)
 	}
 	return signer
 }

--- a/scripts/perf-check.sh
+++ b/scripts/perf-check.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Performance regression gate for the gateway benchmarks.
+#
+# Runs the benchmark suite, reduces each metric to its best-of-N result, and
+# compares that against the recorded baseline in perf-baseline.txt.
+#
+#   scripts/perf-check.sh            # fail if a metric regressed
+#   scripts/perf-check.sh --update   # re-record the baseline
+#
+# Two tolerances, because the metrics differ in how noisy they are:
+#
+#   * Allocation counts (B/op, allocs/op) are deterministic for a given source
+#     tree, so they gate tightly (PERF_ALLOC_TOLERANCE, default 5%). These
+#     catch most real regressions — an extra copy or a new per-request
+#     allocation shows up here long before it shows up in wall-clock time.
+#
+#   * Timing and throughput (ns/op, p50-ms, sessions/s, MB/s) gate loosely
+#     (PERF_TIME_TOLERANCE, default 50%), because shared CI runners are noisy
+#     enough that a tight timing gate would fail on unrelated PRs. Best-of-N
+#     helps — noise only ever makes a benchmark slower, never faster — but it
+#     does not eliminate the spread. Measured run-to-run spread on an idle
+#     machine is up to ~19% for ns/op, so 50% leaves headroom for a busy runner
+#     while still catching the kind of regression that matters.
+#
+#   * Tail latencies (p95-ms, p99-ms) are recorded but NOT gated: they are the
+#     extreme of a bounded sample and swung 17-26% between back-to-back local
+#     runs, which is too noisy to fail a build on. They are the most useful
+#     numbers to eyeball as a trend across the tracked history, which is why
+#     they stay in the baseline file.
+#
+# Machine-dependent by nature: a baseline recorded on a laptop will not match
+# one from a CI runner. The committed baseline is the CI runner's; regenerate
+# it there (the perf workflow's --update mode), not locally.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+BASELINE="${PERF_BASELINE:-perf-baseline.txt}"
+# Fixed iteration counts, not a time budget: a fixed count makes each run
+# comparable to the last, and the concurrency sub-benchmarks need enough
+# iterations that every simulated client gets real work (>= ~8 ops per client
+# at the highest concurrency, which is 64).
+BENCHTIME="${PERF_BENCHTIME:-1000x}"
+COUNT="${PERF_COUNT:-5}"
+PACKAGES="${PERF_PACKAGES:-./pkg/...}"
+ALLOC_TOLERANCE="${PERF_ALLOC_TOLERANCE:-5}"
+TIME_TOLERANCE="${PERF_TIME_TOLERANCE:-50}"
+# Recorded for trend tracking but never gated — see the header note on tails.
+UNGATED_METRICS="${PERF_UNGATED_METRICS:-p95-ms p99-ms}"
+RAW_OUT="${PERF_RAW_OUTPUT:-}"
+
+UPDATE=0
+[[ "${1:-}" == "--update" ]] && UPDATE=1
+
+CUR="$(mktemp)"
+RAW="$(mktemp)"
+trap 'rm -f "$CUR" "$RAW"' EXIT
+
+echo "==> Running benchmarks (benchtime=$BENCHTIME count=$COUNT)"
+# -run '^$' skips tests so only benchmarks execute. GOMAXPROCS is pinned so the
+# concurrency sub-benchmarks schedule the same way run to run.
+GOMAXPROCS="${PERF_GOMAXPROCS:-4}" \
+  go test $PACKAGES -run '^$' -bench . -benchmem \
+  -benchtime="$BENCHTIME" -count="$COUNT" | tee "$RAW"
+
+if [[ -n "$RAW_OUT" ]]; then
+  cp "$RAW" "$RAW_OUT"
+  echo "==> Raw benchmark output saved to $RAW_OUT"
+fi
+
+# Go benchmark lines are: NAME-GOMAXPROCS  ITERS  (VALUE UNIT)...
+#   BenchmarkX/sub-4   1000   1339452 ns/op   98747 B/op   683 allocs/op
+# Reduce each (benchmark, metric) across -count runs to its best value: minimum
+# for lower-is-better metrics, maximum for higher-is-better ones.
+awk '
+  function better(unit, new, old) {
+    # Higher-is-better metrics; everything else is lower-is-better.
+    if (unit == "sessions/s" || unit == "MB/s" || unit == "ops/s") return new > old
+    return new < old
+  }
+  /^Benchmark/ {
+    name = $1
+    sub(/-[0-9]+$/, "", name)   # strip the trailing GOMAXPROCS suffix
+    for (i = 3; i < NF; i += 2) {
+      value = $i
+      unit  = $(i + 1)
+      if (value !~ /^[0-9.]+$/) continue
+      key = name "\t" unit
+      if (!(key in best) || better(unit, value + 0, best[key])) best[key] = value + 0
+    }
+  }
+  END {
+    for (key in best) printf "%s\t%s\n", key, best[key]
+  }
+' "$RAW" | sort > "$CUR"
+
+if [[ ! -s "$CUR" ]]; then
+  echo "error: no benchmark results parsed; did the benchmarks fail to build?" >&2
+  exit 1
+fi
+
+if [[ $UPDATE -eq 1 ]]; then
+  {
+    echo "# Gateway performance baseline for scripts/perf-check.sh."
+    echo "# Format: benchmark<TAB>metric<TAB>best-of-${COUNT} value (benchtime=${BENCHTIME})."
+    echo "#"
+    echo "# Recorded on the CI runner — numbers from a different machine will not"
+    echo "# match. Regenerate with the 'Performance benchmarks' workflow"
+    echo "# (workflow_dispatch, update_baseline=true), not from a laptop."
+    cat "$CUR"
+  } > "$BASELINE"
+  echo "==> Baseline written to $BASELINE"
+  sed 's/^/    /' "$CUR"
+  exit 0
+fi
+
+if [[ ! -f "$BASELINE" ]]; then
+  echo "error: $BASELINE missing; create it with scripts/perf-check.sh --update" >&2
+  exit 1
+fi
+
+echo
+echo "==> Comparing against $BASELINE (alloc ${ALLOC_TOLERANCE}%, timing ${TIME_TOLERANCE}%)"
+fail=0
+new=0
+
+while IFS=$'\t' read -r bench metric cur; do
+  if [[ " $UNGATED_METRICS " == *" $metric "* ]]; then
+    continue
+  fi
+
+  base="$(awk -F'\t' -v b="$bench" -v m="$metric" '$1 == b && $2 == m { print $3 }' "$BASELINE")"
+  if [[ -z "$base" ]]; then
+    printf '    %-62s %-12s %12s  (new, not in baseline)\n' "$bench" "$metric" "$cur"
+    new=1
+    continue
+  fi
+
+  case "$metric" in
+    B/op|allocs/op) tol="$ALLOC_TOLERANCE" ;;
+    *)              tol="$TIME_TOLERANCE"  ;;
+  esac
+
+  # Percent change, signed so that positive always means "worse".
+  read -r delta regressed < <(awk -v c="$cur" -v b="$base" -v m="$metric" -v t="$tol" 'BEGIN {
+    higher_is_better = (m == "sessions/s" || m == "MB/s" || m == "ops/s")
+    if (b == 0) { print 0, 0; exit }
+    pct = (c - b) / b * 100
+    if (higher_is_better) pct = -pct
+    printf "%.1f %d\n", pct, (pct > t) ? 1 : 0
+  }')
+
+  if [[ "$regressed" == "1" ]]; then
+    printf '  x %-62s %-12s %12s  REGRESSED %+.1f%% from %s\n' "$bench" "$metric" "$cur" "$delta" "$base"
+    fail=1
+  elif awk -v d="$delta" -v t="$tol" 'BEGIN { exit !(d < -t) }'; then
+    printf '  + %-62s %-12s %12s  improved %+.1f%% from %s\n' "$bench" "$metric" "$cur" "$delta" "$base"
+  fi
+done < "$CUR"
+
+if [[ $fail -eq 1 ]]; then
+  cat >&2 <<'EOF'
+
+Performance regressed beyond tolerance.
+
+If the change is expected (e.g. added crypto work, a deliberate trade-off),
+re-record the baseline via the "Performance benchmarks" workflow with
+update_baseline=true and commit the result, noting why in the commit message.
+
+If it is not expected, profile the affected benchmark:
+    go test ./pkg/server/ -run '^$' -bench BenchmarkSessionEstablish -cpuprofile cpu.out
+    go tool pprof -top cpu.out
+EOF
+  exit 1
+fi
+
+if [[ $new -eq 1 ]]; then
+  echo
+  echo "New benchmarks are not yet gated — record them with:"
+  echo "    scripts/perf-check.sh --update"
+fi
+
+echo "==> No performance regression"


### PR DESCRIPTION
Description: Establishes a repeatable benchmark suite covering session-establishment latency and gateway throughput under concurrent load, so performance regressions can be caught before shipping rather than discovered by users in production.

Issue:
#74