### PR TITLE
Fix web UI auth docs and make quickstart land signed in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ lab/credentials/
 /agent-key.pub
 /admin-key
 /admin-key.pub
+/client.yaml
+/.orion-known-hosts
 
 # Frontend
 web/ui/node_modules/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Self-hosted SSH/RDP access gateway with PAM workflows, without opening inbound p
 
 ## Try Orion Belt in 10 minutes
 
-Goal: gateway up → agent dials out → SSH works → session recorded.
+Goal: gateway up → agent dials out → SSH works → session recorded. All you need
+is Docker.
 
 ```bash
 git clone https://github.com/orion-belt-dev/orion-belt.git
@@ -42,20 +43,22 @@ cd orion-belt
 ./scripts/docker-quickstart.sh
 ```
 
-Open **http://localhost:8080/ui**, sign in with the printed `admin` username and public key, then:
+One command: it generates its own secrets, starts the gateway, creates your
+admin user, registers a demo machine (`lab-1`), and prints a link that signs you
+in to the console.
 
-1. **Add agent** in the console — save the private key as `./agent-key` (`chmod 600`)
-2. Start an agent (same host is fine for a lab):
+Then, in the console:
 
-```bash
-cp .env.agent.example .env.agent
-# set ORION_SERVER_HOST (e.g. host.docker.internal or your LAN IP) and ORION_AGENT_NAME
-docker compose -f docker-compose.agent.yml --env-file .env.agent up -d
-```
+1. **Machines** → **lab-1** → web terminal — run a few commands
+2. **Sessions** → **Playback** — watch the recording of what you just did
 
-3. Grant yourself access to the machine, SSH in (web terminal or `osh` / OpenSSH), then open **Sessions** to replay or live-watch.
+Same thing from a terminal, if you prefer:
+`./bin/osh -c client.yaml root@lab-1`
 
-Full walkthrough: **[Try Orion Belt in 10 minutes](docs/TRY_IN_10_MINUTES.md)**.
+Stop everything with `./scripts/docker-quickstart.sh --down`.
+
+Full walkthrough, including running an agent on a real machine:
+**[Try Orion Belt in 10 minutes](docs/TRY_IN_10_MINUTES.md)**.
 
 ## Orion Belt vs alternatives
 

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -9,7 +9,10 @@
 #   2. docker compose -f docker-compose.server.yml --env-file .env.server up -d
 #   3. bootstrap the first admin (there's no browser sign-up form — this is
 #      SSH-key auth, not passwords) — see README.md's Docker section for the
-#      exact `... exec ... setup` command, then open http://localhost:8080/ui
+#      exact `... exec ... setup` command
+#   4. sign in with `osh login` (the console has no public-key field; osh proves
+#      possession of the key and opens the browser signed in) — see
+#      docs/TRY_IN_10_MINUTES.md step 2
 #
 # Agents connect to this server on port 2222; see docker-compose.agent.yml.
 
@@ -56,7 +59,40 @@ services:
       - orion_hostkey:/etc/orion-belt
     restart: unless-stopped
 
+  # Lab-only demo agent, started by docker-quickstart.sh so a first run has
+  # something to connect to. Opt-in: `--profile demo`.
+  #
+  # It sits on this compose network, so it reaches the gateway at `server:2222`
+  # — no host IP or host.docker.internal guessing. That convenience is also why
+  # it is not the real deployment path: a production agent runs on the machine
+  # you want to manage and dials out to the gateway over the network. Use
+  # docker-compose.agent.yml for that.
+  agent:
+    profiles: ["demo"]
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.agent
+      target: agent
+    depends_on:
+      - server
+    environment:
+      ORION_SERVER_HOST: "server"
+      ORION_SERVER_PORT: "2222"
+      ORION_AGENT_NAME: "${ORION_AGENT_NAME:-lab-1}"
+      ORION_AGENT_ENV: "lab"
+      # The gateway generates a fresh host key on first run, and this agent has
+      # no known_hosts to pin it against — fine inside a lab network, not a
+      # pattern to copy onto a real one.
+      ORION_STRICT_HOST_KEY_CHECKING: "no"
+    volumes:
+      # Order matters: the state volume mounts before the key bind-mount,
+      # otherwise it would shadow agent_key.
+      - orion_demo_agent_state:/etc/orion-belt
+      - ./agent-key:/etc/orion-belt/agent_key:ro
+    restart: unless-stopped
+
 volumes:
   orion_postgres_data:
   orion_recordings:
   orion_hostkey:
+  orion_demo_agent_state:

--- a/docs/E2E_TEST_PLAN.md
+++ b/docs/E2E_TEST_PLAN.md
@@ -227,17 +227,19 @@ KEEP_IMAGES=1 make lab-qemu-start
 
 **Steps**
 
-1. Confirm `lab/credentials/admin_ed25519.pub` and `UI-LOGIN.txt` exist.
-2. Open `http://127.0.0.1:8080/ui`.
-3. Username: `admin`.
-4. Paste contents of `admin_ed25519.pub` into SSH public key.
-5. Leave TOTP empty; click Sign in.
+1. Confirm `lab/credentials/admin_ed25519` (private), `.pub`, and `UI-LOGIN.txt` exist.
+2. Open `http://127.0.0.1:8080/ui` — check the offered login methods.
+3. Run `./bin/osh -u admin --api-endpoint http://127.0.0.1:8080 -i lab/credentials/admin_ed25519 login --code`.
+4. Open the printed URL, or paste the code into **Device code** on the login screen.
+5. Re-submit the same code a second time.
 
 **Expected results**
 
 1. Files exist; pubkey is a single `ssh-ed25519 …` line.
-2. Login page loads (branded Orion Belt UI).
-3–5. Login succeeds; console shows machines / ops views appropriate for admin (not stuck on login error).
+2. Login page loads (branded Orion Belt UI) offering **Password**, **Security key**, **Device code** — there is no SSH-public-key field, by design.
+3. `osh` authenticates via key challenge-response and prints a 10-char code plus a `/ui/bootstrap?code=…` URL with a 5-minute expiry.
+4. Session is established; console shows machines / ops views appropriate for admin. First login lands on the blocking "create a password + enrol TOTP" gate.
+5. Rejected — codes are single-use.
 
 **Result:** ☐ Pass ☐ Fail ☐ Blocked
 

--- a/docs/TRY_IN_10_MINUTES.md
+++ b/docs/TRY_IN_10_MINUTES.md
@@ -1,16 +1,20 @@
 # Try Orion Belt in 10 minutes
 
-Goal: someone should go **gateway up → agent dials out → SSH works → session recorded → wow**.
+One command gives you a running gateway, a machine to connect to, and a link
+that signs you in. By the end you will have opened a shell through Orion Belt
+and replayed the recording of it.
 
-This is a local lab path. For package installs and production hardening, use [SETUP.md](SETUP.md) and [DEPLOYMENT_HARDENING.md](DEPLOYMENT_HARDENING.md).
+## What you need
 
-## Prerequisites
+- **Docker**, running — [Docker Desktop](https://docs.docker.com/get-docker/) on
+  Mac/Windows, Docker Engine + Compose plugin on Linux
+- A web browser
+- ~10 minutes, most of it waiting for the first build
 
-- Docker + Docker Compose
-- `curl`, `openssl`, `ssh-keygen`
-- ~10 minutes
+No Go, no Node, no config files to edit. If something is missing, the script
+says so before it changes anything.
 
-## 1. Start the gateway (~2 min)
+## 1. Start it
 
 ```bash
 git clone https://github.com/orion-belt-dev/orion-belt.git
@@ -18,112 +22,138 @@ cd orion-belt
 ./scripts/docker-quickstart.sh
 ```
 
-The script:
-
-1. Writes `.env.server` (Postgres password + JWT secret) if missing
-2. Starts Postgres + the Orion Belt server
-3. Waits for `/health`
-4. Creates an `admin` user and prints login material
-
-You should see something like:
+That's the whole setup. It generates its own secrets, starts the gateway,
+creates your admin user, registers a demo machine, and finishes with:
 
 ```text
-== Ready ==
-Web console: http://localhost:8080/ui
-Log in with:
-  username:   admin
-  public key: ssh-ed25519 AAAA... orion-belt-admin
+╔══════════════════════════════════════════════════════════════════╗
+║  Orion Belt is ready                                             ║
+╚══════════════════════════════════════════════════════════════════╝
+
+  1. Sign in — open this link (single use, expires in 5 minutes):
+
+       http://localhost:8080/ui/bootstrap?code=8R76KANQ5F
+
+     You will be asked to create a password and scan a TOTP QR code.
+     That becomes your normal sign-in from then on.
+
+  2. Machine "lab-1" is already connected. Open **Machines**, click its
+     web terminal, and run a few commands.
+
+  3. Open **Sessions** and press Playback to replay what you just did.
 ```
 
-Keep `admin-key` (private) and `admin-key.pub` — both are git-ignored.
+## 2. Sign in
 
-## 2. Sign in to the console (~1 min)
+Open the link. The script also tries to open it for you, so your browser may
+already be there.
 
-1. Open http://localhost:8080/ui
-2. Username: `admin`
-3. Public key: contents of `admin-key.pub`
+Orion Belt then asks you to create a password (10+ characters) and scan a QR
+code with an authenticator app. That is your normal sign-in from then on.
 
-There is no self-service signup; the first admin is bootstrapped from an SSH public key you control.
-
-## 3. Register an agent (~2 min)
-
-1. In the console, open **Add agent**
-2. Pick a name (e.g. `lab-1`) — remember it
-3. Generate / download the agent private key
-4. Save it next to the repo as `./agent-key` and lock it down:
+If the link expired or you need another one:
 
 ```bash
-chmod 600 agent-key
+./bin/osh -c client.yaml login
 ```
 
-Agents dial **out** to the gateway. You do not open inbound SSH on the target.
+<details>
+<summary>Why a link instead of a username and password?</summary>
 
-## 4. Run the agent (~2 min)
+In Orion Belt an identity is an SSH key, not a password. The script generated
+one for you (`admin-key`) and registered it as the first admin. The link is how
+your browser gets to use that key: `osh` proves it holds the private key and the
+gateway hands back a one-time code.
 
-Same machine is fine for a lab:
+A browser cannot sign a challenge with a key file on your disk, so there is no
+"paste your public key" box in the console — that is why the first sign-in comes
+from the command line.
+</details>
+
+## 3. Open a shell on the demo machine
+
+In the console: **Machines** → **lab-1** → open its web terminal. Run a few
+commands, whatever you like:
 
 ```bash
-cp .env.agent.example .env.agent
+whoami
+ls /
 ```
 
-Edit `.env.agent`:
+`lab-1` is a small Linux container the script registered and connected for you,
+so there is something real to connect to. It dialled **out** to the gateway —
+nothing was opened for inbound SSH.
 
-| Variable | Lab value |
+## 4. Replay what you did
+
+**Sessions** → pick the session you just ran → **Playback**. You can also
+**live watch** a session that is still open.
+
+That is the whole product in one loop: access is brokered through the gateway,
+and every session is recorded, without exposing the target's SSH port.
+
+## Optional: the same thing from your terminal
+
+```bash
+./bin/osh -c client.yaml root@lab-1              # interactive shell
+```
+
+Plain OpenSSH works too, no Orion Belt client needed:
+
+```bash
+ssh -i admin-key -p 2222 admin@localhost 'root@lab-1 uptime'
+```
+
+Both are recorded and show up under **Sessions** exactly like the web terminal.
+More forms in [openssh-clients.md](openssh-clients.md).
+
+## Stop it
+
+```bash
+./scripts/docker-quickstart.sh --down
+```
+
+Containers stop and your data volumes are kept, so starting again picks up where
+you left off. To throw the data away too:
+
+```bash
+docker compose -f docker-compose.server.yml --env-file .env.server \
+  --profile demo down --volumes
+```
+
+## If something goes wrong
+
+Re-running `./scripts/docker-quickstart.sh` is always safe — it skips whatever
+is already done and prints a fresh sign-in link. If a lab is already running it
+asks whether to stop and recreate the containers first; your data (users,
+machines, recordings) lives in Docker volumes and is kept either way. Say yes
+unless you have a reason not to — recreating is also what clears a leftover
+container from an interrupted run.
+
+| What you see | What to do |
 | --- | --- |
-| `ORION_AGENT_NAME` | Must match the name you registered (e.g. `lab-1`) |
-| `ORION_SERVER_HOST` | How the agent container reaches the gateway — often `host.docker.internal` (Docker Desktop) or your host LAN IP |
-| `ORION_SERVER_PORT` | `2222` (default) |
+| `port is already allocated` | Something else uses 8080 or 2222. Re-run with different ones: `ORION_API_PORT=18080 ORION_SSH_PORT=12222 ./scripts/docker-quickstart.sh` |
+| "The gateway did not come up" | `docker compose -f docker-compose.server.yml --env-file .env.server logs server` |
+| Sign-in link rejected | Links are single-use and last 5 minutes. Get another: `./bin/osh -c client.yaml login` |
+| `bin/osh` was not built | Your OS/architecture isn't covered by the automatic build. Install [Go](https://go.dev/dl/) and run `make build-client` |
+| **lab-1** shows as offline | `docker compose -f docker-compose.server.yml --env-file .env.server logs agent` |
+| Docker isn't running | Start Docker Desktop (or `sudo systemctl start docker`) and re-run |
 
-Then:
+## Next: a real machine
 
-```bash
-docker compose -f docker-compose.agent.yml --env-file .env.agent up -d
-```
+The demo agent is a shortcut — it runs next to the gateway on the same Docker
+network. To manage a machine you actually care about, run the agent **on that
+machine** with [docker-compose.agent.yml](../docker-compose.agent.yml) (or a
+package from [PACKAGING.md](PACKAGING.md)). It dials out to the gateway, so that
+machine still needs no inbound SSH port.
 
-In the console, the agent should show as connected under **Agents**.
+Skip the demo machine entirely with `./scripts/docker-quickstart.sh --no-agent`.
 
-## 5. Grant access and SSH (~2 min)
+Before you put this on a real network, read
+[DEPLOYMENT_HARDENING.md](DEPLOYMENT_HARDENING.md) — this quick start is a lab:
+it trusts the gateway host key on first use, and WebAuthn and MFA enforcement
+are off. [SETUP.md](SETUP.md) covers turning those on.
 
-1. Ensure your `admin` (or a user you create) can reach the machine — grant the agent / remote user as your role allows (console **Users** / permissions, or admin CLI)
-2. Connect:
-   - **Web terminal** from the console, or
-   - CLI: `osh <agent-name>` (after configuring the client), or
-   - OpenSSH: see [openssh-clients.md](openssh-clients.md)
-
-Run a few commands in the session so there is something to replay.
-
-## 6. Confirm recording (~1 min)
-
-1. Open **Sessions** in the console
-2. Find the session you just ran
-3. **Playback** — or **live watch** if still active
-
-Optional dashboard check (admin/operator/auditor): open **Dashboard → Access analytics** and verify rolling access volume, approval latency, and top targets update without generating a manual report.
-
-That is the conversion moment: outbound agent, mediated SSH, audit trail — without exposing the target’s SSH port.
-
-## Tear down
-
-```bash
-docker compose -f docker-compose.agent.yml --env-file .env.agent down
-docker compose -f docker-compose.server.yml --env-file .env.server down
-# optional: remove volumes if you want a clean slate
-```
-
-## Troubleshooting
-
-| Symptom | Check |
-| --- | --- |
-| Quickstart never becomes healthy | `docker compose -f docker-compose.server.yml --env-file .env.server logs server` |
-| Agent won’t connect | `ORION_SERVER_HOST` / port `2222`; agent name matches registration; `agent-key` is the private key from **Add agent** |
-| Can’t log into UI | Use the **public** key (`admin-key.pub`), not the private key |
-| No recording | Confirm recording is enabled (default in the Docker server path) and the session actually ran through the gateway |
-
-## Next steps
-
-- Turn on MFA / WebAuthn — [SETUP.md](SETUP.md)
-- Optional SSH CA — [SSH_CA.md](SSH_CA.md)
-- Hardening before any real network — [DEPLOYMENT_HARDENING.md](DEPLOYMENT_HARDENING.md)
-- Packages for durable installs — [PACKAGING.md](PACKAGING.md)
-
-**Early operators:** if you deploy this and have feedback, open a [Discussion](https://github.com/orion-belt-dev/orion-belt/discussions) or an issue — we are looking for the first labs and small teams running v1.0.
+**Early operators:** if you deploy this and have feedback, open a
+[Discussion](https://github.com/orion-belt-dev/orion-belt/discussions) or an
+issue — we are looking for the first labs and small teams running v1.0.

--- a/lab/README.md
+++ b/lab/README.md
@@ -19,13 +19,17 @@ After the API is up, bootstrap creates an admin automatically (also part of `mak
 make lab-bootstrap-admin
 ```
 
-Then open **http://127.0.0.1:8080/ui**:
+Then sign in with the CLI — the console has no public-key field, so `osh` does
+the SSH-key challenge-response and opens the browser already signed in:
 
-| Field | Value |
-|-------|--------|
-| Username | `admin` |
-| SSH public key | contents of `lab/credentials/admin_ed25519.pub` |
-| TOTP | leave empty |
+```bash
+make build-client   # if bin/osh isn't built yet
+./bin/osh -u admin --api-endpoint http://127.0.0.1:8080 \
+    -i lab/credentials/admin_ed25519 login
+```
+
+Add `--code` to print a one-time code instead of opening a browser, then paste
+it into **Device code** on the login screen (single-use, 5 min TTL).
 
 Helper details: `lab/credentials/UI-LOGIN.txt`. Demo users: `lab/credentials/USERS.txt`.
 

--- a/lab/bootstrap-admin.sh
+++ b/lab/bootstrap-admin.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Bootstrap a lab admin for the web UI (/ui).
-# Auth is username + SSH public key (no password).
+# Auth is an SSH key challenge-response, driven by `osh login` — the console
+# itself has no public-key field, so the browser is signed in with a one-time
+# code that osh obtains after proving possession of the private key.
 #
 # Usage:
 #   ./lab/bootstrap-admin.sh
@@ -105,14 +107,22 @@ Orion Belt lab — web UI admin login
 
 URL:      $UI_URL
 Username: $USER_NAME
-SSH key:  paste the ONE-LINE public key below into "SSH public key"
-TOTP:     leave empty (unless you enabled MFA)
 
-Public key:
-$PUB
+Sign in from the CLI (nothing is pasted into the browser — it cannot sign
+a challenge with a key file). This opens the browser already signed in:
 
-Private key (keep local, for osh/ssh later):
+  ./bin/osh -u $USER_NAME --api-endpoint $API -i $KEY_PATH login
+
+Headless? Add --code to print a one-time code and URL instead, then use the
+"Device code" option on the login screen. Codes are single-use, 5 min TTL.
+
+If bin/osh is missing: make build-client
+
+Private key (also used by osh/ssh):
 $KEY_PATH
+
+Public key (registered on the server):
+$PUB
 
 Re-run bootstrap:
   make lab-bootstrap-admin
@@ -121,14 +131,16 @@ EOF
 cat <<EOF
 
 ╔══════════════════════════════════════════════════════════╗
-║  Lab admin ready — open the UI and sign in               ║
+║  Lab admin ready — sign in with osh                      ║
 ╚══════════════════════════════════════════════════════════╝
 
   UI:       $UI_URL
   Username: $USER_NAME
-  Pubkey:   ${KEY_PATH}.pub
 
-  cat ${KEY_PATH}.pub
+  ./bin/osh -u $USER_NAME --api-endpoint $API -i $KEY_PATH login
+
+  (opens the browser signed in; add --code for headless hosts,
+   and run 'make build-client' first if bin/osh is missing)
 
 Details written to: $LOGIN_FILE
 EOF

--- a/scripts/docker-quickstart.sh
+++ b/scripts/docker-quickstart.sh
@@ -1,77 +1,321 @@
 #!/usr/bin/env bash
-# Orion Belt — one-command Docker quick start.
+# Orion Belt — one-command quick start.
 #
-# Brings up the server stack, generates the secrets it needs, and bootstraps
-# the first admin user — the pieces docker-compose.server.yml deliberately
-# doesn't automate on its own (secrets shouldn't be silently invented by a
-# compose file, and admin bootstrap is a security-sensitive one-time step).
+# Takes a fresh checkout to a signed-in web console with one connectable
+# machine, so a first run ends in a working demo instead of a setup checklist.
+# It generates the secrets, starts the gateway, bootstraps the first admin,
+# builds the `osh` client, registers a lab agent, and prints a sign-in link.
 #
-# Usage: ./scripts/docker-quickstart.sh
-# Safe to re-run: skips any step that's already done.
+# Usage:
+#   ./scripts/docker-quickstart.sh              # everything (recommended)
+#   ./scripts/docker-quickstart.sh --no-agent   # gateway + sign-in only
+#   ./scripts/docker-quickstart.sh --down       # stop it all again
+#
+# Safe to re-run: every step skips itself if it is already done.
+#
+# This is a local lab, not a deployment. See docs/DEPLOYMENT_HARDENING.md
+# before putting Orion Belt on a real network.
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-COMPOSE=(docker compose -f docker-compose.server.yml --env-file .env.server)
 API_PORT="${ORION_API_PORT:-8080}"
+SSH_PORT="${ORION_SSH_PORT:-2222}"
+AGENT_NAME="${ORION_AGENT_NAME:-lab-1}"
+CFG=/etc/orion-belt/config.generated.yaml
+GO_IMAGE="${ORION_GO_IMAGE:-golang:1.26.5-alpine}"
 
-echo "== Orion Belt Docker quick start =="
+WITH_AGENT=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-agent|--no-demo-agent) WITH_AGENT=0 ;;
+    --down|--stop)
+      echo "-> stopping Orion Belt"
+      docker compose -f docker-compose.server.yml --env-file .env.server \
+        --profile demo down
+      echo "Stopped. Data volumes were kept; add --volumes to remove them."
+      exit 0
+      ;;
+    -h|--help) sed -n '2,17p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown option: $arg (try --help)" >&2; exit 2 ;;
+  esac
+done
 
-# 1. Secrets: generate .env.server if it doesn't exist yet.
+COMPOSE=(docker compose -f docker-compose.server.yml --env-file .env.server)
+TOTAL=6
+[ "$WITH_AGENT" -eq 1 ] && TOTAL=7
+STEP=0
+step() { STEP=$((STEP + 1)); printf '\n[%d/%d] %s\n' "$STEP" "$TOTAL" "$1"; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+echo "== Orion Belt quick start =="
+
+# ---------------------------------------------------------------- preflight
+have docker || { echo "Docker is required: https://docs.docker.com/get-docker/" >&2; exit 1; }
+docker compose version >/dev/null 2>&1 || {
+  echo "Docker Compose v2 is required (try: docker compose version)" >&2; exit 1; }
+docker info >/dev/null 2>&1 || {
+  echo "Docker is installed but not running — start Docker Desktop (or dockerd) and re-run." >&2; exit 1; }
+for tool in openssl ssh-keygen curl; do
+  have "$tool" || { echo "Missing required tool: $tool" >&2; exit 1; }
+done
+
+# ------------------------------------------------------------------ secrets
+step "Secrets"
 if [ ! -f .env.server ]; then
-  echo "-> generating .env.server (Postgres password + JWT secret)"
   {
     echo "POSTGRES_PASSWORD=$(openssl rand -hex 24)"
     echo "ORION_JWT_SECRET=$(openssl rand -hex 32)"
   } > .env.server
+  chmod 600 .env.server
+  echo "   generated .env.server"
 else
-  echo "-> .env.server already exists, reusing it"
+  echo "   .env.server already exists — reusing it"
 fi
 
-# 2. Bring the stack up.
-echo "-> starting Postgres + server (docker compose up -d --build)"
+# ---------------------------------------------------------------- key pairs
+# Generated before `compose up` because the agent service bind-mounts
+# ./agent-key: if the file is missing, Docker would create a directory there.
+step "Keys"
+if [ ! -f admin-key ]; then
+  ssh-keygen -t ed25519 -f admin-key -N "" -C "orion-belt-admin" -q
+  echo "   generated admin-key (your sign-in identity)"
+else
+  echo "   admin-key already exists — reusing it"
+fi
+if [ "$WITH_AGENT" -eq 1 ] && [ ! -f agent-key ]; then
+  ssh-keygen -t ed25519 -f agent-key -N "" -C "orion-belt-agent-$AGENT_NAME" -q
+  chmod 600 agent-key
+  echo "   generated agent-key (identity of machine '$AGENT_NAME')"
+fi
+
+# ------------------------------------------------------------------ gateway
+step "Gateway (first run builds the image — a few minutes)"
+
+# sanity check — the project name is used to find containers to stop and remove
+PROJECT="${COMPOSE_PROJECT_NAME:-$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')}"
+project_containers() {
+  docker ps -aq --filter "label=com.docker.compose.project=$PROJECT" 2>/dev/null
+}
+
+existing=$(project_containers || true)
+if [ -n "$existing" ]; then
+  echo "   an Orion Belt lab already exists here:"
+  docker ps -a --filter "label=com.docker.compose.project=$PROJECT" \
+    --format '{{.Names}}  ({{.Status}})' 2>/dev/null | sed 's/^/     /' || true
+  recreate=1
+  if [ -t 0 ]; then
+    printf '\n   Stop and recreate its containers? Your data is kept. [Y/n] '
+    read -r reply
+    case "$reply" in [Nn]*) recreate=0 ;; esac
+  else
+    echo "   (not a terminal — recreating automatically)"
+  fi
+  if [ "$recreate" -eq 1 ]; then
+    "${COMPOSE[@]}" --profile demo down --remove-orphans >/dev/null 2>&1 || true
+    leftover=$(project_containers || true)
+    if [ -n "$leftover" ]; then
+      # What `down` leaves behind: a container renamed mid-recreate still holds
+      # the name compose wants, so remove it by ID.
+      # shellcheck disable=SC2086
+      docker rm -f $leftover >/dev/null 2>&1 || true
+    fi
+    echo "   removed — starting fresh containers"
+  else
+    echo "   leaving it as it is (a name clash may still stop the rebuild)"
+  fi
+fi
+
+# Check the ports before compose does, so a clash produces advice instead of a
+# raw "port is already allocated". Skipped once our own gateway is up, since
+# then the ports are supposed to be in use — by us.
+port_busy() { (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null; }
+if [ -z "$("${COMPOSE[@]}" ps -q server 2>/dev/null)" ]; then
+  clash=""
+  port_busy "$API_PORT" && clash="$clash $API_PORT"
+  port_busy "$SSH_PORT" && clash="$clash $SSH_PORT"
+  if [ -n "$clash" ]; then
+    echo "   ! something else is already listening on:$clash" >&2
+    echo "     Re-run on free ports, for example:" >&2
+    echo "       ORION_API_PORT=18080 ORION_SSH_PORT=12222 $0" >&2
+    exit 1
+  fi
+fi
+
 "${COMPOSE[@]}" up -d --build
 
-# 3. Wait for the API to answer.
-echo -n "-> waiting for the server to become healthy"
-for _ in $(seq 1 30); do
+printf '   waiting for the gateway to answer'
+for _ in $(seq 1 60); do
   if curl -sf "http://localhost:${API_PORT}/health" >/dev/null 2>&1; then
-    echo " ✓"
-    break
+    printf ' ok\n'; break
   fi
-  echo -n "."
-  sleep 2
+  printf '.'; sleep 2
 done
 if ! curl -sf "http://localhost:${API_PORT}/health" >/dev/null 2>&1; then
-  echo
-  echo "Server didn't become healthy in time. Check: ${COMPOSE[*]} logs server" >&2
+  printf '\n'
+  echo "The gateway did not come up. Logs:" >&2
+  echo "  ${COMPOSE[*]} logs server" >&2
+  echo "If port ${API_PORT} or ${SSH_PORT} is already in use, re-run with" >&2
+  echo "  ORION_API_PORT=18080 ORION_SSH_PORT=12222 $0" >&2
   exit 1
 fi
 
-# 4. Admin keypair: generate one locally if missing.
-if [ ! -f admin-key ]; then
-  echo "-> generating admin-key (ed25519 keypair for the first admin login)"
-  ssh-keygen -t ed25519 -f admin-key -N "" -C "orion-belt-admin" -q
-fi
-
-# 5. Bootstrap the first admin, if one doesn't exist yet. The setup command is
-# idempotent about this (it detects an existing admin and no-ops), so it's
-# safe to run every time this script runs.
-echo "-> ensuring an admin user exists"
+# --------------------------------------------------------------- admin user
+# `setup` detects an existing admin and no-ops, so this is safe every run.
+step "Admin user"
 "${COMPOSE[@]}" exec -T \
   -e ORION_SETUP_ADMIN_NAME=admin \
   -e ORION_SETUP_ADMIN_EMAIL=admin@localhost \
   -e ORION_SETUP_ADMIN_KEY="$(cat admin-key.pub)" \
-  server /app/orion-belt-server -c /etc/orion-belt/config.generated.yaml setup < /dev/null
+  server /app/orion-belt-server -c "$CFG" setup < /dev/null >/dev/null
+echo "   admin ready (authenticates with admin-key)"
 
-echo
-echo "== Ready =="
-echo "Web console: http://localhost:${API_PORT}/ui"
-echo "Log in with:"
-echo "  username:   admin"
-echo "  public key: $(cat admin-key.pub)"
-echo
-echo "(admin-key is your private key — keep it, it's how the CLI/API"
-echo " authenticate as this user too. It's already git-ignored.)"
-echo
-echo "Next: register a machine (web console -> Add agent), then see"
-echo "docker-compose.agent.yml to run an agent on it."
+# ------------------------------------------------------------- osh client
+# Signing in to the console goes through osh: it proves possession of
+# admin-key and hands the browser a one-time code. A browser cannot sign a
+# challenge with a key file, which is why there is no key field in the UI.
+step "Sign-in client (bin/osh)"
+if [ -x bin/osh ]; then
+  echo "   bin/osh already built — reusing it"
+elif have go; then
+  make build-client >/dev/null
+  echo "   built bin/osh with your Go toolchain"
+else
+  # No Go on the host: cross-build for this OS/arch inside the same Go image
+  # the gateway was built with. Pure Go, so this needs no C toolchain.
+  case "$(uname -s)" in
+    Linux) goos=linux ;;
+    Darwin) goos=darwin ;;
+    *) goos="" ;;
+  esac
+  case "$(uname -m)" in
+    x86_64 | amd64) goarch=amd64 ;;
+    arm64 | aarch64) goarch=arm64 ;;
+    *) goarch="" ;;
+  esac
+  if [ -z "$goos" ] || [ -z "$goarch" ]; then
+    echo "   ! cannot auto-build osh for $(uname -s)/$(uname -m)" >&2
+    echo "     Install Go and run: make build-client" >&2
+  else
+    echo "   no Go toolchain — building osh in Docker ($goos/$goarch)"
+    mkdir -p bin
+    docker run --rm \
+      -v "$PWD":/src -w /src \
+      --user "$(id -u):$(id -g)" \
+      -e HOME=/tmp -e GOPATH=/tmp/gopath \
+      -e GOCACHE=/tmp/gocache -e GOMODCACHE=/tmp/gomod \
+      -e GOOS="$goos" -e GOARCH="$goarch" -e CGO_ENABLED=0 \
+      "$GO_IMAGE" go build -o bin/osh ./cmd/osh
+    echo "   built bin/osh"
+  fi
+fi
+
+# ------------------------------------------------------------- client config
+# Written here so osh never has to run its interactive setup wizard.
+if [ ! -f client.yaml ]; then
+  cat > client.yaml <<EOF
+# Orion Belt client config for this lab (generated by docker-quickstart.sh).
+# Use it with: ./bin/osh -c client.yaml ...
+server:
+  host: "localhost"
+  port: ${SSH_PORT}
+  api_endpoint: "http://localhost:${API_PORT}"
+auth:
+  user: "admin"
+  key_file: "${PWD}/admin-key"
+  known_hosts: "${PWD}/.orion-known-hosts"
+  strict_host_key_checking: "ask"
+EOF
+  chmod 600 client.yaml
+fi
+
+# ------------------------------------------------------------- demo machine
+if [ "$WITH_AGENT" -eq 1 ]; then
+  step "Demo machine '$AGENT_NAME'"
+  if "${COMPOSE[@]}" exec -T server /app/orion-belt-server -c "$CFG" \
+        agent list 2>/dev/null | grep -qw "$AGENT_NAME"; then
+    echo "   '$AGENT_NAME' is already registered"
+  else
+    "${COMPOSE[@]}" exec -T server /app/orion-belt-server -c "$CFG" \
+      agent register --name "$AGENT_NAME" --key "$(cat agent-key.pub)" \
+      >/dev/null
+    "${COMPOSE[@]}" exec -T server /app/orion-belt-server -c "$CFG" \
+      permission grant --user admin --machine "$AGENT_NAME" \
+      --type both --remote-users root >/dev/null
+    echo "   registered '$AGENT_NAME' and granted admin access to it"
+  fi
+  "${COMPOSE[@]}" --profile demo up -d --build agent
+  echo "   agent container started (dials out to the gateway)"
+fi
+
+# ------------------------------------------------------------- sign-in link
+step "Sign-in link"
+LINK=""
+if [ -x bin/osh ]; then
+  # --code prints the one-time code and URL instead of opening a browser,
+  # so the link can be shown in this summary either way.
+  if OUT=$(./bin/osh -c client.yaml login --code 2>&1); then
+    LINK=$(printf '%s\n' "$OUT" | awk '/^URL:/ {print $2}')
+  fi
+  if [ -z "$LINK" ]; then
+    echo "   ! could not get a sign-in link automatically:" >&2
+    printf '%s\n' "$OUT" | sed 's/^/     /' >&2
+  fi
+fi
+
+cat <<EOF
+
+╔══════════════════════════════════════════════════════════════════╗
+║  Orion Belt is ready                                             ║
+╚══════════════════════════════════════════════════════════════════╝
+EOF
+
+if [ -n "$LINK" ]; then
+  cat <<EOF
+
+  1. Sign in — open this link (single use, expires in 5 minutes):
+
+       $LINK
+
+     You will be asked to create a password and scan a TOTP QR code.
+     That becomes your normal sign-in from then on.
+EOF
+  # Best effort: most people would rather it just opened.
+  if have xdg-open; then (xdg-open "$LINK" >/dev/null 2>&1 &) || true
+  elif have open; then (open "$LINK" >/dev/null 2>&1 &) || true
+  fi
+else
+  cat <<EOF
+
+  1. Sign in — get a fresh link any time with:
+
+       ./bin/osh -c client.yaml login          # opens your browser
+       ./bin/osh -c client.yaml login --code   # prints a link instead
+EOF
+fi
+
+if [ "$WITH_AGENT" -eq 1 ]; then
+  cat <<EOF
+
+  2. Machine "$AGENT_NAME" is already connected. Open **Machines**, click its
+     web terminal, and run a few commands.
+
+  3. Open **Sessions** and press Playback to replay what you just did.
+EOF
+else
+  cat <<EOF
+
+  2. Add a machine: **Add agent** in the console, then see
+     docker-compose.agent.yml to run the agent on it.
+EOF
+fi
+
+cat <<EOF
+
+  Console:  http://localhost:${API_PORT}/ui
+  Stop:     $0 --down
+  Guide:    docs/TRY_IN_10_MINUTES.md
+
+  admin-key is your private key. Keep it — the CLI and API authenticate
+  with it too. It is git-ignored, along with agent-key and client.yaml.
+
+EOF

--- a/web/ui/src/pages/SecurityPage.tsx
+++ b/web/ui/src/pages/SecurityPage.tsx
@@ -389,7 +389,19 @@ export function SecurityPage() {
               </div>
               {backupCodes.length ? (
                 <>
-                  <label className="field">Backup codes — save these now</label>
+                  <div className="row" style={{ justifyContent: "space-between", alignItems: "baseline" }}>
+                    <label className="field">Backup codes — save these now</label>
+                    <button
+                      type="button"
+                      className="btn secondary sm"
+                      onClick={async () => {
+                        await navigator.clipboard.writeText(backupCodes.join("\n"));
+                        toast("Backup codes copied");
+                      }}
+                    >
+                      Copy
+                    </button>
+                  </div>
                   <pre className="session">{backupCodes.join("\n")}</pre>
                 </>
               ) : null}
@@ -447,7 +459,19 @@ export function SecurityPage() {
                 <input className="mono" readOnly value={secret} />
                 {backupCodes.length ? (
                   <>
-                    <label className="field">Backup codes</label>
+                    <div className="row" style={{ justifyContent: "space-between", alignItems: "baseline" }}>
+                      <label className="field">Backup codes</label>
+                      <button
+                        type="button"
+                        className="btn secondary sm"
+                        onClick={async () => {
+                          await navigator.clipboard.writeText(backupCodes.join("\n"));
+                          toast("Backup codes copied");
+                        }}
+                      >
+                        Copy
+                      </button>
+                    </div>
                     <pre className="session">{backupCodes.join("\n")}</pre>
                   </>
                 ) : null}

--- a/web/ui/src/pages/SetPasswordGate.tsx
+++ b/web/ui/src/pages/SetPasswordGate.tsx
@@ -107,7 +107,19 @@ export function SetPasswordGate() {
             </div>
             {backupCodes.length ? (
               <>
-                <label className="field">Backup codes — save these now</label>
+                <div className="row" style={{ justifyContent: "space-between", alignItems: "baseline" }}>
+                  <label className="field">Backup codes — save these now</label>
+                  <button
+                    type="button"
+                    className="btn secondary sm"
+                    onClick={async () => {
+                      await navigator.clipboard.writeText(backupCodes.join("\n"));
+                      toast("Backup codes copied");
+                    }}
+                  >
+                    Copy
+                  </button>
+                </div>
                 <pre className="session">{backupCodes.join("\n")}</pre>
               </>
             ) : null}

--- a/web/ui/src/styles/theme.css
+++ b/web/ui/src/styles/theme.css
@@ -521,6 +521,11 @@ button.os-card span { font-size: 0.78rem; }
 
 pre.code, pre.session {
   background: #070d0f;
+  /* The background is pinned dark in both themes, so pin the foreground too
+     (same pair the xterm hosts use). Inheriting var(--text) makes these blocks
+     near-black on near-black in light mode — which silently hid MFA backup
+     codes and agent install scripts. */
+  color: #e8f0f2;
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   padding: 1rem;


### PR DESCRIPTION
## Summary
- Docs, bootstrap, and E2E steps told people to paste an SSH public key into the console — that field does not exist anymore. First sign-in is via `osh login` (one-time bootstrap link / device code after a key challenge).
- Rework `docker-quickstart.sh` so one command brings up the gateway, admin, `osh` client, a demo `lab-1` agent (`--profile demo`), and a ready-to-open sign-in link.
- Fix light-mode MFA backup codes (and other `pre.session` blocks) that were near-invisible on a pinned dark background, and add a Copy control for those codes.

## Test plan
- [x] Fresh checkout: `./scripts/docker-quickstart.sh` → open printed link → password + TOTP gate → Machines → lab-1 web terminal → Sessions playback
- [x] Re-run quickstart (idempotent): reuses secrets/keys, prints a fresh link; `--down` stops the stack
- [x] `./scripts/docker-quickstart.sh --no-agent` starts gateway + sign-in only (no demo agent)
- [x] Expired/reused bootstrap code is rejected; `./bin/osh -c client.yaml login` issues a new one
- [x] Lab path: `make lab-bootstrap-admin` then `osh … login` / `--code` as documented
- [x] Light theme: MFA backup codes readable; Copy button works on Security / SetPasswordGate