### PR TITLE
Default Add-agent package URL to public GitHub Pages mirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,3 +93,40 @@ jobs:
           name: orion-belt-repos
           path: repos/
           if-no-files-found: warn
+
+      - name: Build packages Pages tree
+        env:
+          ORION_PKG_TAG: ${{ github.ref_name }}
+          ORION_DIST: dist
+          PACKAGES_DEPLOY_KEY: ${{ secrets.PACKAGES_DEPLOY_KEY }}
+        run: |
+          if ls dist/orion-belt-agent*.deb >/dev/null 2>&1; then
+            bash scripts/publish-packages-pages.sh
+          else
+            bash scripts/publish-packages-pages.sh --from-release
+          fi
+          echo "has_deploy_key=false" >> "$GITHUB_OUTPUT"
+          if [ -n "$PACKAGES_DEPLOY_KEY" ]; then
+            echo "has_deploy_key=true" >> "$GITHUB_OUTPUT"
+          fi
+        id: packages_pages
+
+      - name: Upload packages-site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: orion-belt-packages-site
+          path: packages-site/
+          if-no-files-found: warn
+
+      - name: Push packages-site to orion-belt-dev/packages (gh-pages)
+        if: steps.packages_pages.outputs.has_deploy_key == 'true'
+        env:
+          PACKAGES_DEPLOY_KEY: ${{ secrets.PACKAGES_DEPLOY_KEY }}
+          ORION_PKG_TAG: ${{ github.ref_name }}
+        run: |
+          eval "$(ssh-agent -s)"
+          echo "$PACKAGES_DEPLOY_KEY" | tr -d '\r' | ssh-add -
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          bash scripts/publish-packages-pages.sh --push

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ recordings/
 # Release / packaging output
 dist/
 repos/
+packages-site/
 
 # QEMU / compose lab state
 lab/qemu/images/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
         bench perf-check perf-baseline \
         docker-build docker-build-server docker-build-agent docker-build-client \
         docker-push docker-up docker-down docker-logs docker-agent-up docker-agent-down \
-        cve packages repos packaging-key sign-artifacts lab-compose-up lab-compose-down lab-bootstrap-admin \
+        cve packages repos packaging-key sign-artifacts serve-packages publish-packages-pages \
+        lab-compose-up lab-compose-down lab-bootstrap-admin \
         lab-qemu-images lab-qemu-images-refresh lab-qemu-up lab-qemu-down lab-qemu-restart lab-qemu-test \
         lab-qemu-connect-agents lab-qemu-collect-keys lab-qemu-register-agents \
         lab-qemu-clean lab-qemu-start lab-qemu-update
@@ -200,6 +201,17 @@ cve:
 packages:
 	bash scripts/package.sh
 
+# Serve dist/ on :8765 for Add-agent / local installs (ORION_PKG_PORT, ORION_PKG_BUILD=1)
+serve-packages:
+	bash scripts/serve-packages.sh
+
+# Build flat GitHub Pages tree (packages-site/). Push: make publish-packages-pages PUSH=1
+# From release assets: make publish-packages-pages FROM_RELEASE=1
+publish-packages-pages:
+	bash scripts/publish-packages-pages.sh \
+		$(if $(filter 1,$(FROM_RELEASE)),--from-release,) \
+		$(if $(filter 1,$(PUSH)),--push,)
+
 # Build static apt/rpm/apk repos under repos/ (after make packages)
 # Signed: ./scripts/gen-packaging-key.sh && ORION_REQUIRE_SIGN=1 make repos
 repos:
@@ -212,7 +224,6 @@ packaging-key:
 # Detached GPG signatures + SHA256SUMS for dist/
 sign-artifacts:
 	bash scripts/sign-artifacts.sh
-
 lab-compose-up:
 	bash lab/compose/bootstrap-keys.sh
 	docker compose -f lab/compose/docker-compose.yml up -d --build

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -128,6 +128,8 @@ For Alpine index signing, set `ORION_APK_PRIVKEY` / `ORION_APK_PUBKEY` when call
 
 Wire the script into release CD after GoReleaser to refresh the hosted repo.
 
+The Release workflow also builds a flat **Add-agent** mirror under `packages-site/` (artifact `orion-belt-packages-site`). To auto-push it to [`orion-belt-dev/packages`](https://github.com/orion-belt-dev/packages) `gh-pages`, set repo secret `PACKAGES_DEPLOY_KEY` (deploy key with write access). Without it, download the artifact and run `make publish-packages-pages PUSH=1` locally.
+
 ### Arch Linux
 
 Binary packages via `packaging/arch/PKGBUILD` (reads GitHub release tarballs):
@@ -150,4 +152,23 @@ sudo systemctl enable --now orion-belt-server
 orion-belt-server setup
 ```
 
-To enroll hosts quickly, use the UI **Add agent** flow (or `POST /api/v1/admin/agents/install-script`). Point **package base URL** at a directory that serves the artifacts from `make packages` / `dist/` (or your published apt/rpm/apk/GitHub release URLs).
+To enroll hosts quickly, use the UI **Add agent** flow (or `POST /api/v1/admin/agents/install-script`). The default **package base URL** is the public GitHub Pages mirror:
+
+```text
+https://orion-belt-dev.github.io/packages
+```
+
+That site is the [`orion-belt-dev/packages`](https://github.com/orion-belt-dev/packages) repo (`gh-pages`). Refresh it after a release:
+
+```bash
+make publish-packages-pages FROM_RELEASE=1 PUSH=1
+# or from local dist/:
+make packages && make publish-packages-pages PUSH=1
+```
+
+For a **local** package server (dev builds, air-gapped, or custom `dist/`):
+
+```bash
+make packages
+make serve-packages   # http://127.0.0.1:8765 — set that as Package base URL
+```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -93,7 +93,7 @@ orion-belt-server -c /etc/orion-belt/server.yaml setup
 1. Sign in as **admin** or **operator**.
 2. Open **Add agent** in the console.
 3. Choose the target OS (Debian/Ubuntu, RHEL/Rocky, openSUSE, Alpine, or generic Linux).
-4. Set agent name, gateway host (SSH port **2222**), and **package base URL** (where `orion-belt-agent` packages/binary are hosted — GitHub Releases, your apt/rpm/apk mirror, or a lab HTTP root serving `dist/`).
+4. Set agent name, gateway host (SSH port **2222**), and **package base URL**. The UI defaults to the public mirror [`https://orion-belt-dev.github.io/packages`](https://orion-belt-dev.github.io/packages) (version **1.0.0** when the gateway build is untagged). For a local `dist/` build instead: `make packages && make serve-packages`, then set the base URL to `http://127.0.0.1:8765` (or your host IP).
 5. **Generate install script** — the server registers the agent and returns a root shell script that embeds the agent private key, downloads the package, writes `/etc/orion-belt/agent.yaml`, and starts the service.
 6. Copy or download the script and run it on the target host as root.
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1341,8 +1341,9 @@ paths:
            starts `orion-belt-agent`
 
         The private key is embedded in the script — treat it as a secret.
-        `package_base_url` must serve agent artifacts (e.g. GitHub Releases,
-        apt/rpm mirror, or lab `:8765` serving `dist/`).
+        `package_base_url` must serve agent artifacts. Default in the UI is
+        the public mirror `https://orion-belt-dev.github.io/packages`
+        (or lab `:8765` via `make serve-packages`).
       requestBody:
         required: true
         content:
@@ -2305,11 +2306,11 @@ components:
         package_base_url:
           type: string
           description: Base URL that serves orion-belt-agent packages/binary
-          example: https://packages.example.com
+          example: https://orion-belt-dev.github.io/packages
         version:
           type: string
           description: Package version string (without leading v). Defaults to server build version.
-          example: "0.6.0"
+          example: "1.0.0"
     AgentInstallScriptResponse:
       type: object
       properties:

--- a/lab/README.md
+++ b/lab/README.md
@@ -153,6 +153,7 @@ Networking:
 - Management SSH: server `:2200`, agents `:2201`–`:2204`.
 
 `dist/` is served over HTTP on `:8765` so cloud-init can install packages or raw binaries.
+Outside the lab you can run the same mirror with `make serve-packages`, or use the public Pages URL `https://orion-belt-dev.github.io/packages`.
 
 Images: `lab/qemu/images/` (gitignored). Overlays/logs: `lab/qemu/run/`. Credentials: `lab/credentials/` (gitignored).
 

--- a/pkg/api/agent_install.go
+++ b/pkg/api/agent_install.go
@@ -250,7 +250,14 @@ agent:
 	switch osID {
 	case "debian":
 		b.WriteString(`echo "==> Installing orion-belt-agent (deb)"
-if curl -fsSL -o /tmp/orion-belt-agent.deb "$PKG_BASE/orion-belt-agent_${VERSION}_amd64.deb"; then
+DEB=""
+for cand in \
+  "$PKG_BASE/orion-belt-agent_${VERSION}_amd64.deb" \
+  "$PKG_BASE/orion-belt-agent_${VERSION}_linux_amd64.deb"
+do
+  if curl -fsSL -o /tmp/orion-belt-agent.deb "$cand"; then DEB=1; break; fi
+done
+if [ -n "$DEB" ]; then
   dpkg -i /tmp/orion-belt-agent.deb || apt-get install -f -y
   rm -f /tmp/orion-belt-agent.deb
 elif curl -fsSL -o /usr/bin/orion-belt-agent "$PKG_BASE/orion-belt-agent"; then
@@ -262,7 +269,14 @@ fi
 `)
 	case "rhel":
 		b.WriteString(`echo "==> Installing orion-belt-agent (rpm)"
-if curl -fsSL -o /tmp/orion-belt-agent.rpm "$PKG_BASE/orion-belt-agent-${VERSION}-1.x86_64.rpm"; then
+RPM=""
+for cand in \
+  "$PKG_BASE/orion-belt-agent-${VERSION}-1.x86_64.rpm" \
+  "$PKG_BASE/orion-belt-agent_${VERSION}_linux_amd64.rpm"
+do
+  if curl -fsSL -o /tmp/orion-belt-agent.rpm "$cand"; then RPM=1; break; fi
+done
+if [ -n "$RPM" ]; then
   if command -v dnf >/dev/null 2>&1; then dnf -y install /tmp/orion-belt-agent.rpm
   elif command -v yum >/dev/null 2>&1; then yum -y localinstall /tmp/orion-belt-agent.rpm
   else rpm -Uvh /tmp/orion-belt-agent.rpm; fi
@@ -276,7 +290,14 @@ fi
 `)
 	case "suse":
 		b.WriteString(`echo "==> Installing orion-belt-agent (rpm / zypper)"
-if curl -fsSL -o /tmp/orion-belt-agent.rpm "$PKG_BASE/orion-belt-agent-${VERSION}-1.x86_64.rpm"; then
+RPM=""
+for cand in \
+  "$PKG_BASE/orion-belt-agent-${VERSION}-1.x86_64.rpm" \
+  "$PKG_BASE/orion-belt-agent_${VERSION}_linux_amd64.rpm"
+do
+  if curl -fsSL -o /tmp/orion-belt-agent.rpm "$cand"; then RPM=1; break; fi
+done
+if [ -n "$RPM" ]; then
   zypper -n install /tmp/orion-belt-agent.rpm || rpm -Uvh /tmp/orion-belt-agent.rpm
   rm -f /tmp/orion-belt-agent.rpm
 elif curl -fsSL -o /usr/bin/orion-belt-agent "$PKG_BASE/orion-belt-agent"; then
@@ -288,7 +309,14 @@ fi
 `)
 	case "alpine":
 		b.WriteString(`echo "==> Installing orion-belt-agent (apk)"
-if curl -fsSL -o /tmp/orion-belt-agent.apk "$PKG_BASE/orion-belt-agent_${VERSION}_x86_64.apk"; then
+APK=""
+for cand in \
+  "$PKG_BASE/orion-belt-agent_${VERSION}_x86_64.apk" \
+  "$PKG_BASE/orion-belt-agent_${VERSION}_linux_amd64.apk"
+do
+  if curl -fsSL -o /tmp/orion-belt-agent.apk "$cand"; then APK=1; break; fi
+done
+if [ -n "$APK" ]; then
   apk add --allow-untrusted /tmp/orion-belt-agent.apk
   rm -f /tmp/orion-belt-agent.apk
 elif curl -fsSL -o /usr/bin/orion-belt-agent "$PKG_BASE/orion-belt-agent"; then

--- a/scripts/publish-packages-pages.sh
+++ b/scripts/publish-packages-pages.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Build a flat GitHub Pages tree for Add-agent package downloads.
+#
+# Layout matches install-script filenames:
+#   orion-belt-agent_${VERSION}_amd64.deb
+#   orion-belt-agent-${VERSION}-1.x86_64.rpm
+#   orion-belt-agent_${VERSION}_x86_64.apk
+#   orion-belt-agent   (linux/amd64 binary fallback)
+# plus GoReleaser originals (*_linux_amd64.*) when present.
+#
+# Sources (first match wins):
+#   1. ORION_DIST / dist/  (after make packages / goreleaser)
+#   2. GitHub Release assets for ORION_PKG_TAG (default: latest tag)
+#
+# Usage:
+#   make packages && ./scripts/publish-packages-pages.sh
+#   ORION_PKG_TAG=v1.0.0 ./scripts/publish-packages-pages.sh --from-release
+#   ./scripts/publish-packages-pages.sh --push   # commit+push to orion-belt-dev/packages gh-pages
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST="${ORION_DIST:-$ROOT/dist}"
+OUT="${ORION_PACKAGES_OUT:-$ROOT/packages-site}"
+REPO_SLUG="${ORION_PACKAGES_REPO:-orion-belt-dev/packages}"
+PAGES_URL="${ORION_PACKAGES_URL:-https://orion-belt-dev.github.io/packages}"
+FROM_RELEASE=0
+PUSH=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --from-release) FROM_RELEASE=1 ;;
+    --push) PUSH=1 ;;
+    -h|--help)
+      sed -n '2,20p' "$0"
+      exit 0
+      ;;
+  esac
+done
+
+die() { echo "$*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null || die "missing: $1"; }
+
+need curl
+need python3
+
+resolve_tag() {
+  if [[ -n "${ORION_PKG_TAG:-}" ]]; then
+    echo "${ORION_PKG_TAG}"
+    return
+  fi
+  local tag
+  tag="$(git -C "$ROOT" describe --tags --abbrev=0 2>/dev/null || true)"
+  if [[ -n "$tag" ]]; then
+    echo "$tag"
+    return
+  fi
+  curl -fsSL "https://api.github.com/repos/orion-belt-dev/orion-belt/releases/latest" \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin)["tag_name"])'
+}
+
+TAG="$(resolve_tag)"
+VER="${TAG#v}"
+RELEASE_BASE="https://github.com/orion-belt-dev/orion-belt/releases/download/${TAG}"
+
+echo "==> Building packages Pages tree → $OUT (version $VER)"
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+download() {
+  local url="$1" dest="$2"
+  echo "  fetch $url"
+  curl -fsSL -o "$dest" "$url"
+}
+
+# Prefer binaries extracted from arch-correct .deb over release tarballs
+# (tarball naming has been wrong in at least one release).
+extract_agent_from_deb() {
+  local deb="$1" dest="$2"
+  local tmp
+  tmp="$(mktemp -d)"
+  (cd "$tmp" && ar x "$deb" && tar xf data.tar.*)
+  local bin
+  bin="$(find "$tmp" -type f -path '*/usr/bin/orion-belt-agent' | head -1)"
+  [[ -n "$bin" ]] || die "no orion-belt-agent inside $deb"
+  cp -f "$bin" "$dest"
+  chmod 755 "$dest"
+  rm -rf "$tmp"
+}
+
+copy_or_fetch() {
+  local name="$1" url="$2"
+  if [[ -f "$DIST/$name" ]]; then
+    cp -f "$DIST/$name" "$OUT/$name"
+    return 0
+  fi
+  if [[ "$FROM_RELEASE" == "1" ]] || [[ ! -d "$DIST" ]]; then
+    download "$url" "$OUT/$name" || return 1
+    return 0
+  fi
+  return 1
+}
+
+# Collect agent packages from dist/ or the release.
+shopt -s nullglob
+have_local=0
+if [[ -d "$DIST" ]]; then
+  for f in "$DIST"/orion-belt-agent*.{deb,rpm,apk}; do
+    cp -f "$f" "$OUT/$(basename "$f")"
+    have_local=1
+  done
+  if [[ -f "$DIST/orion-belt-agent" ]]; then
+    cp -f "$DIST/orion-belt-agent" "$OUT/orion-belt-agent"
+    chmod 755 "$OUT/orion-belt-agent"
+    have_local=1
+  fi
+fi
+
+if [[ "$have_local" -eq 0 || "$FROM_RELEASE" == "1" ]]; then
+  echo "==> Fetching agent packages from $RELEASE_BASE"
+  for arch in amd64 arm64; do
+    copy_or_fetch "orion-belt-agent_${VER}_linux_${arch}.deb" \
+      "$RELEASE_BASE/orion-belt-agent_${VER}_linux_${arch}.deb" || true
+    copy_or_fetch "orion-belt-agent_${VER}_linux_${arch}.rpm" \
+      "$RELEASE_BASE/orion-belt-agent_${VER}_linux_${arch}.rpm" || true
+    copy_or_fetch "orion-belt-agent_${VER}_linux_${arch}.apk" \
+      "$RELEASE_BASE/orion-belt-agent_${VER}_linux_${arch}.apk" || true
+  done
+fi
+
+# Install-script aliases (nfpm / UI / QEMU cloud-init names).
+alias_one() {
+  local src="$1" dst="$2"
+  [[ -f "$OUT/$src" ]] || return 0
+  cp -f "$OUT/$src" "$OUT/$dst"
+  echo "  alias $dst ← $src"
+}
+
+# deb: drop _linux_
+alias_one "orion-belt-agent_${VER}_linux_amd64.deb" "orion-belt-agent_${VER}_amd64.deb"
+alias_one "orion-belt-agent_${VER}_linux_arm64.deb" "orion-belt-agent_${VER}_arm64.deb"
+# Also accept plain nfpm names already in dist/
+if [[ -f "$OUT/orion-belt-agent_${VER}_amd64.deb" && ! -f "$OUT/orion-belt-agent_${VER}_linux_amd64.deb" ]]; then
+  : # local nfpm layout — already correct for install script
+fi
+
+# apk: goreleaser uses linux_amd64; install script wants x86_64 / aarch64
+alias_one "orion-belt-agent_${VER}_linux_amd64.apk" "orion-belt-agent_${VER}_x86_64.apk"
+alias_one "orion-belt-agent_${VER}_linux_arm64.apk" "orion-belt-agent_${VER}_aarch64.apk"
+
+# rpm: install script wants classic NEVRA; goreleaser uses _linux_amd64
+alias_one "orion-belt-agent_${VER}_linux_amd64.rpm" "orion-belt-agent-${VER}-1.x86_64.rpm"
+alias_one "orion-belt-agent_${VER}_linux_arm64.rpm" "orion-belt-agent-${VER}-1.aarch64.rpm"
+
+# Prefer arch-correct binaries from .deb packages
+if [[ -f "$OUT/orion-belt-agent_${VER}_amd64.deb" ]]; then
+  extract_agent_from_deb "$OUT/orion-belt-agent_${VER}_amd64.deb" "$OUT/orion-belt-agent"
+  cp -f "$OUT/orion-belt-agent" "$OUT/orion-belt-agent_linux_amd64"
+fi
+if [[ -f "$OUT/orion-belt-agent_${VER}_arm64.deb" ]]; then
+  extract_agent_from_deb "$OUT/orion-belt-agent_${VER}_arm64.deb" "$OUT/orion-belt-agent_linux_arm64"
+elif [[ -f "$OUT/orion-belt-agent_${VER}_linux_arm64.deb" ]]; then
+  extract_agent_from_deb "$OUT/orion-belt-agent_${VER}_linux_arm64.deb" "$OUT/orion-belt-agent_linux_arm64"
+fi
+
+# If only plain nfpm deb names exist (no _linux_), still extract binary
+if [[ ! -f "$OUT/orion-belt-agent" && -f "$OUT/orion-belt-agent_${VER}_amd64.deb" ]]; then
+  extract_agent_from_deb "$OUT/orion-belt-agent_${VER}_amd64.deb" "$OUT/orion-belt-agent"
+fi
+
+[[ -f "$OUT/orion-belt-agent_${VER}_amd64.deb" || -f "$OUT/orion-belt-agent" ]] \
+  || die "No agent packages found — run make packages or pass --from-release"
+
+printf '%s\n' "$VER" >"$OUT/VERSION"
+printf '%s\n' "$TAG" >"$OUT/TAG"
+touch "$OUT/.nojekyll"
+
+cat >"$OUT/index.html" <<EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Orion Belt packages</title>
+  <style>
+    body { font-family: ui-sans-serif, system-ui, sans-serif; max-width: 52rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; color: #111; }
+    code { background: #f4f4f5; padding: 0.1em 0.35em; border-radius: 4px; }
+    a { color: #0b57d0; }
+  </style>
+</head>
+<body>
+  <h1>Orion Belt packages</h1>
+  <p>Static package mirror for <strong>Add agent</strong> install scripts.</p>
+  <p>Package base URL: <code>${PAGES_URL}</code></p>
+  <p>Current release: <a href="VERSION">VERSION</a> / <a href="TAG">TAG</a> (${VER}).</p>
+  <p>Filenames match the install script
+     (<code>orion-belt-agent_\${VERSION}_amd64.deb</code>, etc.)
+     plus GoReleaser originals (<code>*_linux_amd64.*</code>).</p>
+  <p>Source: <a href="https://github.com/orion-belt-dev/orion-belt/releases">GitHub Releases</a>.
+     Repo: <a href="https://github.com/${REPO_SLUG}">${REPO_SLUG}</a>.
+     Local mirror: <code>make serve-packages</code>.</p>
+</body>
+</html>
+EOF
+
+echo "==> Wrote $(find "$OUT" -type f | wc -l | tr -d ' ') files to $OUT"
+
+if [[ "$PUSH" != "1" ]]; then
+  echo "Done. To publish: $0 --push"
+  echo "Or: git -C <clone of ${REPO_SLUG}> checkout gh-pages && rsync -a --delete $OUT/ . && git commit && git push"
+  exit 0
+fi
+
+need git
+WORKDIR="$(mktemp -d)"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+echo "==> Pushing to ${REPO_SLUG} (gh-pages)"
+git clone --branch gh-pages --single-branch "git@github.com:${REPO_SLUG}.git" "$WORKDIR/repo" \
+  || git clone "git@github.com:${REPO_SLUG}.git" "$WORKDIR/repo"
+
+cd "$WORKDIR/repo"
+if ! git rev-parse --verify gh-pages >/dev/null 2>&1; then
+  git checkout --orphan gh-pages
+  git rm -rf . >/dev/null 2>&1 || true
+else
+  git checkout gh-pages
+fi
+
+# Replace tree but keep .git
+find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+cp -a "$OUT"/. .
+git add -A
+if git diff --cached --quiet; then
+  echo "No changes to publish."
+  exit 0
+fi
+git -c user.name="${GIT_AUTHOR_NAME:-orion-belt-bot}" \
+    -c user.email="${GIT_AUTHOR_EMAIL:-maintainers@orion-belt.dev}" \
+    commit -m "Publish agent packages ${TAG}"
+git push -u origin gh-pages
+echo "Published → ${PAGES_URL}/"

--- a/scripts/serve-packages.sh
+++ b/scripts/serve-packages.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Serve dist/ over HTTP for local Add-agent / QEMU installs.
+#
+# Usage:
+#   make packages && make serve-packages
+#   ORION_PKG_PORT=9000 make serve-packages
+#
+# Then set Package base URL to http://localhost:8765 (or your host IP).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST="${ORION_DIST:-$ROOT/dist}"
+PORT="${ORION_PKG_PORT:-8765}"
+BUILD="${ORION_PKG_BUILD:-0}"
+
+if [[ ! -d "$DIST" ]] || [[ -z "$(ls -A "$DIST" 2>/dev/null || true)" ]]; then
+  if [[ "$BUILD" == "1" ]]; then
+    echo "==> dist/ empty — running make packages"
+    (cd "$ROOT" && make packages)
+  else
+    echo "No packages in $DIST — run: make packages" >&2
+    echo "Or: ORION_PKG_BUILD=1 make serve-packages" >&2
+    exit 1
+  fi
+fi
+
+if ! command -v python3 >/dev/null; then
+  echo "python3 required to serve packages" >&2
+  exit 1
+fi
+
+if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "Port $PORT already in use — stop the other server or set ORION_PKG_PORT" >&2
+  lsof -nP -iTCP:"$PORT" -sTCP:LISTEN || true
+  exit 1
+fi
+
+BIND="${ORION_PKG_BIND:-0.0.0.0}"
+echo "Serving $DIST at http://${BIND}:$PORT/"
+echo "Add agent → Package base URL: http://127.0.0.1:$PORT  (or http://<host-ip>:$PORT)"
+echo "Ctrl-C to stop."
+cd "$DIST"
+exec python3 -m http.server "$PORT" --bind "$BIND"

--- a/web/ui/src/pages/AddAgentPage.tsx
+++ b/web/ui/src/pages/AddAgentPage.tsx
@@ -13,6 +13,11 @@ import logoSuse from "../assets/distros/suse.png";
 import logoAlpine from "../assets/distros/alpine.png";
 import logoLinux from "../assets/distros/linux.png";
 
+/** Public GitHub Pages mirror (orion-belt-dev/packages). Local: make serve-packages → :8765 */
+const DEFAULT_PACKAGE_BASE_URL = "https://orion-belt-dev.github.io/packages";
+/** Matches the seeded Pages release when the gateway build is untagged/dev. */
+const DEFAULT_PACKAGE_VERSION = "1.0.0";
+
 const OS_OPTIONS = [
   {
     id: "debian",
@@ -68,11 +73,11 @@ export function AddAgentPage() {
   const [env, setEnv] = useState("production");
   const [gw, setGw] = useState(window.location.hostname || "127.0.0.1");
   const [gwPort, setGwPort] = useState(2222);
-  const [pkg, setPkg] = useState(window.location.origin.replace(/:\d+$/, "") + ":8765");
+  const [pkg, setPkg] = useState(DEFAULT_PACKAGE_BASE_URL);
   const [ver, setVer] = useState(() => {
-    let v = version?.version || version?.display || "0.0.0";
+    let v = version?.version || version?.display || DEFAULT_PACKAGE_VERSION;
     if (String(v).startsWith("v")) v = String(v).slice(1);
-    if (v === "dev") v = "0.0.0";
+    if (v === "dev" || v === "0.0.0") v = DEFAULT_PACKAGE_VERSION;
     return String(v);
   });
   const [script, setScript] = useState("");
@@ -176,7 +181,11 @@ export function AddAgentPage() {
           </div>
           <div>
             <label className="field">Package base URL</label>
-            <input value={pkg} onChange={(e) => setPkg(e.target.value)} />
+            <input
+              value={pkg}
+              onChange={(e) => setPkg(e.target.value)}
+              placeholder={DEFAULT_PACKAGE_BASE_URL}
+            />
           </div>
           <div>
             <label className="field">Package version</label>


### PR DESCRIPTION
## Summary
- Seed Add agent with `https://orion-belt-dev.github.io/packages` (version `1.0.0` when the gateway build is untagged/dev) instead of a non-running `:8765` default.
- Add `make serve-packages` for a local `dist/` HTTP mirror, and `make publish-packages-pages` to refresh the `orion-belt-dev/packages` Pages site.
- Wire the release workflow to build/upload the packages site (and push when `PACKAGES_DEPLOY_KEY` is set); install scripts now try both nfpm and GoReleaser package names.

## Test plan
- [x] Open Add agent and confirm Package base URL / version defaults
- [x] Generate an install script and confirm it curls the Pages URLs for the chosen OS
- [x] `make packages && make serve-packages`, point Package base URL at `http://127.0.0.1:8765`, generate + dry-run curl of artifacts
- [x] `make publish-packages-pages FROM_RELEASE=1` builds `packages-site/` with install-script aliases
- [x] Rebuild UI (`make build-ui` / docker stack) so the console picks up the new defaults