### PR TITLE
GHCR images, packages Pages publish, and prod compose on :latest

### DIFF
--- a/.env.prod.agent.example
+++ b/.env.prod.agent.example
@@ -1,0 +1,14 @@
+# Copy to .env.prod.agent, then:
+#   docker compose -f docker-compose.prod.agent.yml --env-file .env.prod.agent pull
+#   docker compose -f docker-compose.prod.agent.yml --env-file .env.prod.agent up -d
+#
+# Register the agent in the console first; save its key as ./agent-key (chmod 600).
+
+ORION_SERVER_HOST=
+ORION_AGENT_NAME=
+
+# Optional
+# ORION_IMAGE_TAG=latest
+# ORION_SERVER_PORT=2222
+# ORION_AGENT_ENV=production
+# ORION_STRICT_HOST_KEY_CHECKING=ask

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,24 @@
+# Copy to .env.prod, then:
+#   docker compose -f docker-compose.prod.yml --env-file .env.prod pull
+#   docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+#
+# Images: ghcr.io/orion-belt-dev/orion-belt-server:${ORION_IMAGE_TAG:-latest}
+
+# Required
+POSTGRES_PASSWORD=
+ORION_JWT_SECRET=
+ORION_PUBLIC_HOST=orion.example.com
+ORION_PUBLIC_ORIGIN=https://orion.example.com
+
+# Optional — image tag (default: latest). Pin with e.g. 1.1.0 or v1.1.0
+# ORION_IMAGE_TAG=latest
+
+# Optional
+# POSTGRES_USER=orionbelt
+# POSTGRES_DB=orionbelt
+# ORION_SSH_PORT=2222
+# ORION_API_PORT=8080
+# ORION_MFA_REQUIRED=false
+# ORION_WEBAUTHN_ENABLED=true
+# ORION_RECORDING_ENCRYPTION_KEY=
+# ORION_RECORDING_RETENTION_DAYS=90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -94,39 +95,89 @@ jobs:
           path: repos/
           if-no-files-found: warn
 
-      - name: Build packages Pages tree
+      - name: Publish packages Pages (orion-belt-dev/packages)
         env:
           ORION_PKG_TAG: ${{ github.ref_name }}
           ORION_DIST: dist
+          # Cross-repo push — GITHUB_TOKEN cannot write to another repo.
+          # Prefer a fine-grained PAT (contents:write on orion-belt-dev/packages):
+          ORION_PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
+          # Or an SSH deploy key with write access on that repo:
           PACKAGES_DEPLOY_KEY: ${{ secrets.PACKAGES_DEPLOY_KEY }}
         run: |
+          set -euo pipefail
+          if [[ -z "${ORION_PACKAGES_TOKEN:-}" && -z "${PACKAGES_DEPLOY_KEY:-}" ]]; then
+            echo "::error::Set repo secret PACKAGES_TOKEN (PAT) or PACKAGES_DEPLOY_KEY (SSH) so Release can push to orion-belt-dev/packages gh-pages."
+            echo "Without it, make publish-packages-pages PUSH=1 cannot run in CI (GITHUB_TOKEN is scoped to this repo only)."
+            exit 1
+          fi
           if ls dist/orion-belt-agent*.deb >/dev/null 2>&1; then
-            bash scripts/publish-packages-pages.sh
+            make publish-packages-pages PUSH=1
           else
-            bash scripts/publish-packages-pages.sh --from-release
+            make publish-packages-pages FROM_RELEASE=1 PUSH=1
           fi
-          echo "has_deploy_key=false" >> "$GITHUB_OUTPUT"
-          if [ -n "$PACKAGES_DEPLOY_KEY" ]; then
-            echo "has_deploy_key=true" >> "$GITHUB_OUTPUT"
-          fi
-        id: packages_pages
 
       - name: Upload packages-site artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: orion-belt-packages-site
           path: packages-site/
           if-no-files-found: warn
 
-      - name: Push packages-site to orion-belt-dev/packages (gh-pages)
-        if: steps.packages_pages.outputs.has_deploy_key == 'true'
-        env:
-          PACKAGES_DEPLOY_KEY: ${{ secrets.PACKAGES_DEPLOY_KEY }}
-          ORION_PKG_TAG: ${{ github.ref_name }}
+      - name: Set up QEMU (multi-arch images)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker image metadata
+        id: meta
         run: |
-          eval "$(ssh-agent -s)"
-          echo "$PACKAGES_DEPLOY_KEY" | tr -d '\r' | ssh-add -
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          bash scripts/publish-packages-pages.sh --push
+          TAG="${GITHUB_REF_NAME}"
+          VER="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+          # workflow_dispatch without a tag → latest only
+          if [[ "$TAG" == v* ]]; then
+            echo "server_tags=ghcr.io/orion-belt-dev/orion-belt-server:${VER},ghcr.io/orion-belt-dev/orion-belt-server:${TAG},ghcr.io/orion-belt-dev/orion-belt-server:latest" >> "$GITHUB_OUTPUT"
+            echo "agent_tags=ghcr.io/orion-belt-dev/orion-belt-agent:${VER},ghcr.io/orion-belt-dev/orion-belt-agent:${TAG},ghcr.io/orion-belt-dev/orion-belt-agent:latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "server_tags=ghcr.io/orion-belt-dev/orion-belt-server:latest" >> "$GITHUB_OUTPUT"
+            echo "agent_tags=ghcr.io/orion-belt-dev/orion-belt-agent:latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push server image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: server
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.server_tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/orion-belt-dev/orion-belt
+            org.opencontainers.image.description=Orion Belt PAM gateway server
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+
+      - name: Build and push agent image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.agent
+          target: agent
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.agent_tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/orion-belt-dev/orion-belt
+            org.opencontainers.image.description=Orion Belt reverse-SSH agent
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ lab/credentials/
 .env
 .env.server
 .env.agent
+.env.prod
+.env.prod.agent
 /agent-key
 /agent-key.pub
 /admin-key

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
         test-coverage coverage-check coverage-baseline \
         bench perf-check perf-baseline \
         docker-build docker-build-server docker-build-agent docker-build-client \
-        docker-push docker-up docker-down docker-logs docker-agent-up docker-agent-down \
+        docker-push docker-push-server docker-push-agent \
+        docker-up docker-down docker-logs docker-agent-up docker-agent-down \
+        docker-prod-pull docker-prod-up docker-prod-down \
+        docker-prod-agent-up docker-prod-agent-down \
         cve packages repos packaging-key sign-artifacts serve-packages publish-packages-pages \
         lab-compose-up lab-compose-down lab-bootstrap-admin \
         lab-qemu-images lab-qemu-images-refresh lab-qemu-up lab-qemu-down lab-qemu-restart lab-qemu-test \
@@ -26,12 +29,14 @@ LDFLAGS = -s -w \
 	-X github.com/orion-belt-dev/orion-belt/pkg/version.Date=$(DATE)
 
 # Docker variables
-DOCKER_REGISTRY ?=
+# Default registry for pushes: GitHub Container Registry under the org.
+DOCKER_REGISTRY ?= ghcr.io/orion-belt-dev
 DOCKER_IMAGE ?= orion-belt
 DOCKER_TAG ?= latest
 DOCKER_DIR=docker
 DOCKERFILE=$(DOCKER_DIR)/Dockerfile
 DOCKERFILE_AGENT=$(DOCKER_DIR)/Dockerfile.agent
+DOCKER_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Helper to prefix image name with registry if set
 ifdef DOCKER_REGISTRY
@@ -156,6 +161,8 @@ docker-build-server:
 		--file $(DOCKERFILE) \
 		--target server \
 		--tag $(IMAGE_PREFIX)-server:$(DOCKER_TAG) \
+		--label org.opencontainers.image.source=https://github.com/orion-belt-dev/orion-belt \
+		--label org.opencontainers.image.description="Orion Belt PAM gateway server" \
 		.
 
 # Build agent image
@@ -165,7 +172,24 @@ docker-build-agent:
 		--file $(DOCKERFILE_AGENT) \
 		--target agent \
 		--tag $(IMAGE_PREFIX)-agent:$(DOCKER_TAG) \
+		--label org.opencontainers.image.source=https://github.com/orion-belt-dev/orion-belt \
+		--label org.opencontainers.image.description="Orion Belt reverse-SSH agent" \
 		.
+
+# Build both images locally
+docker-build: docker-build-server docker-build-agent
+
+# Push to GHCR (login first: echo $$GITHUB_TOKEN | docker login ghcr.io -u USER --password-stdin)
+# Override: DOCKER_TAG=1.1.0 make docker-push
+docker-push-server: docker-build-server
+	docker push $(IMAGE_PREFIX)-server:$(DOCKER_TAG)
+
+docker-push-agent: docker-build-agent
+	docker push $(IMAGE_PREFIX)-agent:$(DOCKER_TAG)
+
+docker-push: docker-push-server docker-push-agent
+	@echo "Pushed $(IMAGE_PREFIX)-server:$(DOCKER_TAG) and $(IMAGE_PREFIX)-agent:$(DOCKER_TAG)"
+	@echo "Also listed on https://orion-belt-dev.github.io/packages (CONTAINERS)"
 
 # Start the server + Postgres via Docker Compose (see .env.server.example)
 docker-up:
@@ -188,6 +212,26 @@ docker-agent-up:
 # Stop the agent
 docker-agent-down:
 	docker compose -f docker-compose.agent.yml --env-file .env.agent down
+
+# Production stack from GHCR (:latest by default — always pull on up)
+#   cp .env.prod.example .env.prod && make docker-prod-up
+docker-prod-pull:
+	docker compose -f docker-compose.prod.yml --env-file .env.prod pull
+
+docker-prod-up:
+	docker compose -f docker-compose.prod.yml --env-file .env.prod pull
+	docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+	@echo "Prod server up (GHCR $${ORION_IMAGE_TAG:-latest}). SSH: :$${ORION_SSH_PORT:-2222}  UI: http://localhost:$${ORION_API_PORT:-8080}/ui"
+
+docker-prod-down:
+	docker compose -f docker-compose.prod.yml --env-file .env.prod down
+
+docker-prod-agent-up:
+	docker compose -f docker-compose.prod.agent.yml --env-file .env.prod.agent pull
+	docker compose -f docker-compose.prod.agent.yml --env-file .env.prod.agent up -d
+
+docker-prod-agent-down:
+	docker compose -f docker-compose.prod.agent.yml --env-file .env.prod.agent down
 
 # ────────────────────────────────────────────────────────────
 # Security / packaging / labs

--- a/README.md
+++ b/README.md
@@ -119,6 +119,22 @@ See [Try in 10 minutes](docs/TRY_IN_10_MINUTES.md) for agent + first session.
 
 Step-by-step compose (secrets + admin bootstrap): same script, or the manual path in that doc. Make targets: `docker-up` / `docker-down` / `docker-agent-up`.
 
+Published images (GHCR):
+
+```bash
+docker pull ghcr.io/orion-belt-dev/orion-belt-server:latest
+docker pull ghcr.io/orion-belt-dev/orion-belt-agent:latest
+```
+
+Production compose (always pulls `:latest` unless you set `ORION_IMAGE_TAG`):
+
+```bash
+cp .env.prod.example .env.prod   # set secrets + public host/origin
+make docker-prod-up              # or: docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+```
+
+Agent on a managed host: `docker-compose.prod.agent.yml` / `make docker-prod-agent-up`.
+
 ### Packages (deb / rpm / apk)
 
 ```bash

--- a/docker-compose.prod.agent.yml
+++ b/docker-compose.prod.agent.yml
@@ -1,0 +1,30 @@
+# Orion Belt — production agent (published GHCR image)
+#
+# Always tracks: ghcr.io/orion-belt-dev/orion-belt-agent:latest
+#
+# Run on each host you want to manage (agent dials out — no inbound ports).
+#
+#   1. Register the agent in the console (Add agent) and save the key as ./agent-key
+#   2. cp .env.prod.agent.example .env.prod.agent  (set host + agent name)
+#   3. docker compose -f docker-compose.prod.agent.yml --env-file .env.prod.agent pull
+#   4. docker compose -f docker-compose.prod.agent.yml --env-file .env.prod.agent up -d
+#
+# Pin a release: ORION_IMAGE_TAG=1.1.0
+
+services:
+  agent:
+    image: "ghcr.io/orion-belt-dev/orion-belt-agent:${ORION_IMAGE_TAG:-latest}"
+    pull_policy: always
+    environment:
+      ORION_SERVER_HOST: "${ORION_SERVER_HOST:?set ORION_SERVER_HOST in .env.prod.agent}"
+      ORION_SERVER_PORT: "${ORION_SERVER_PORT:-2222}"
+      ORION_AGENT_NAME: "${ORION_AGENT_NAME:?set ORION_AGENT_NAME in .env.prod.agent}"
+      ORION_AGENT_ENV: "${ORION_AGENT_ENV:-production}"
+      ORION_STRICT_HOST_KEY_CHECKING: "${ORION_STRICT_HOST_KEY_CHECKING:-ask}"
+    volumes:
+      - orion_prod_agent_state:/etc/orion-belt
+      - ./agent-key:/etc/orion-belt/agent_key:ro
+    restart: unless-stopped
+
+volumes:
+  orion_prod_agent_state:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,65 @@
+# Orion Belt — production stack (published GHCR images)
+#
+# Always tracks the latest released images from GitHub Container Registry:
+#   ghcr.io/orion-belt-dev/orion-belt-server:latest
+#   (agent: see docker-compose.prod.agent.yml)
+#
+#   1. cp .env.prod.example .env.prod
+#      Fill POSTGRES_PASSWORD and ORION_JWT_SECRET (openssl rand -hex 32).
+#      Set ORION_PUBLIC_HOST / ORION_PUBLIC_ORIGIN to your real domain.
+#   2. docker compose -f docker-compose.prod.yml --env-file .env.prod pull
+#   3. docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+#   4. Bootstrap admin (SSH-key auth — no browser sign-up):
+#        docker compose -f docker-compose.prod.yml --env-file .env.prod \
+#          exec server /app/orion-belt-server setup
+#
+# Dev / local builds from source: use docker-compose.server.yml instead.
+#
+# Image tags: override ORION_IMAGE_TAG (default latest). pin e.g. ORION_IMAGE_TAG=1.1.0
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: "${POSTGRES_USER:-orionbelt}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.prod}"
+      POSTGRES_DB: "${POSTGRES_DB:-orionbelt}"
+    volumes:
+      - orion_prod_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-orionbelt}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  server:
+    image: "ghcr.io/orion-belt-dev/orion-belt-server:${ORION_IMAGE_TAG:-latest}"
+    pull_policy: always
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "${ORION_SSH_PORT:-2222}:2222"
+      - "${ORION_API_PORT:-8080}:8080"
+    environment:
+      POSTGRES_HOST: "postgres"
+      POSTGRES_USER: "${POSTGRES_USER:-orionbelt}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.prod}"
+      POSTGRES_DB: "${POSTGRES_DB:-orionbelt}"
+      ORION_JWT_SECRET: "${ORION_JWT_SECRET:?set ORION_JWT_SECRET in .env.prod, generate with 'openssl rand -hex 32'}"
+      ORION_MFA_REQUIRED: "${ORION_MFA_REQUIRED:-false}"
+      ORION_WEBAUTHN_ENABLED: "${ORION_WEBAUTHN_ENABLED:-true}"
+      ORION_PUBLIC_HOST: "${ORION_PUBLIC_HOST:?set ORION_PUBLIC_HOST in .env.prod}"
+      ORION_PUBLIC_ORIGIN: "${ORION_PUBLIC_ORIGIN:?set ORION_PUBLIC_ORIGIN in .env.prod}"
+      ORION_RECORDING_ENCRYPTION_KEY: "${ORION_RECORDING_ENCRYPTION_KEY:-}"
+      ORION_RECORDING_RETENTION_DAYS: "${ORION_RECORDING_RETENTION_DAYS:-90}"
+    volumes:
+      - orion_prod_recordings:/var/lib/orion-belt/recordings
+      - orion_prod_hostkey:/etc/orion-belt
+    restart: unless-stopped
+
+volumes:
+  orion_prod_postgres_data:
+  orion_prod_recordings:
+  orion_prod_hostkey:

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -128,7 +128,19 @@ For Alpine index signing, set `ORION_APK_PRIVKEY` / `ORION_APK_PUBKEY` when call
 
 Wire the script into release CD after GoReleaser to refresh the hosted repo.
 
-The Release workflow also builds a flat **Add-agent** mirror under `packages-site/` (artifact `orion-belt-packages-site`). To auto-push it to [`orion-belt-dev/packages`](https://github.com/orion-belt-dev/packages) `gh-pages`, set repo secret `PACKAGES_DEPLOY_KEY` (deploy key with write access). Without it, download the artifact and run `make publish-packages-pages PUSH=1` locally.
+The Release workflow runs `make publish-packages-pages … PUSH=1` after GoReleaser.
+`GITHUB_TOKEN` cannot push to another repository, so set **one** of these secrets on `orion-belt`:
+
+| Secret | Purpose |
+|--------|---------|
+| `PACKAGES_TOKEN` | Fine-grained PAT (or classic) with **Contents: Read and write** on [`orion-belt-dev/packages`](https://github.com/orion-belt-dev/packages) |
+| `PACKAGES_DEPLOY_KEY` | SSH deploy key (write) on that same repo |
+
+Without either secret the Release job **fails** on the publish step (instead of silently skipping). Locally you can still run:
+
+```bash
+make publish-packages-pages FROM_RELEASE=1 PUSH=1
+```
 
 ### Arch Linux
 
@@ -172,3 +184,41 @@ For a **local** package server (dev builds, air-gapped, or custom `dist/`):
 make packages
 make serve-packages   # http://127.0.0.1:8765 — set that as Package base URL
 ```
+
+## Container images (GHCR)
+
+Release tags push multi-arch (`linux/amd64`, `linux/arm64`) images to GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/orion-belt-dev/orion-belt-server:1.1.0
+docker pull ghcr.io/orion-belt-dev/orion-belt-agent:1.1.0
+# or :latest
+```
+
+Local build + push (after `docker login ghcr.io`):
+
+```bash
+DOCKER_TAG=1.1.0 make docker-push
+```
+
+Image refs for the current mirror release are also listed at
+[`https://orion-belt-dev.github.io/packages/CONTAINERS`](https://orion-belt-dev.github.io/packages/CONTAINERS).
+
+## Production Docker Compose
+
+Pull published images (always refresh `:latest`):
+
+```bash
+cp .env.prod.example .env.prod
+make docker-prod-up
+```
+
+Agent hosts:
+
+```bash
+cp .env.prod.agent.example .env.prod.agent
+make docker-prod-agent-up
+```
+
+Override tag with `ORION_IMAGE_TAG=1.1.0` to pin. Source builds stay on `docker-compose.server.yml`.
+

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -93,7 +93,7 @@ orion-belt-server -c /etc/orion-belt/server.yaml setup
 1. Sign in as **admin** or **operator**.
 2. Open **Add agent** in the console.
 3. Choose the target OS (Debian/Ubuntu, RHEL/Rocky, openSUSE, Alpine, or generic Linux).
-4. Set agent name, gateway host (SSH port **2222**), and **package base URL**. The UI defaults to the public mirror [`https://orion-belt-dev.github.io/packages`](https://orion-belt-dev.github.io/packages) (version **1.0.0** when the gateway build is untagged). For a local `dist/` build instead: `make packages && make serve-packages`, then set the base URL to `http://127.0.0.1:8765` (or your host IP).
+4. Set agent name, gateway host (SSH port **2222**), and **package base URL**. The UI defaults to the public mirror [`https://orion-belt-dev.github.io/packages`](https://orion-belt-dev.github.io/packages) and loads **Package version** from that mirror’s `VERSION` file. For a local `dist/` build instead: `make packages && make serve-packages`, then set the base URL to `http://127.0.0.1:8765` (or your host IP).
 5. **Generate install script** — the server registers the agent and returns a root shell script that embeds the agent private key, downloads the package, writes `/etc/orion-belt/agent.yaml`, and starts the service.
 6. Copy or download the script and run it on the target host as root.
 

--- a/scripts/publish-packages-pages.sh
+++ b/scripts/publish-packages-pages.sh
@@ -16,6 +16,10 @@
 #   make packages && ./scripts/publish-packages-pages.sh
 #   ORION_PKG_TAG=v1.0.0 ./scripts/publish-packages-pages.sh --from-release
 #   ./scripts/publish-packages-pages.sh --push   # commit+push to orion-belt-dev/packages gh-pages
+#
+# Push auth (required for --push / PUSH=1):
+#   ORION_PACKAGES_TOKEN or PACKAGES_TOKEN  — HTTPS PAT with contents:write on packages
+#   PACKAGES_DEPLOY_KEY                    — SSH deploy key (write) on packages
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -174,6 +178,23 @@ printf '%s\n' "$VER" >"$OUT/VERSION"
 printf '%s\n' "$TAG" >"$OUT/TAG"
 touch "$OUT/.nojekyll"
 
+SERVER_IMG="ghcr.io/orion-belt-dev/orion-belt-server"
+AGENT_IMG="ghcr.io/orion-belt-dev/orion-belt-agent"
+cat >"$OUT/CONTAINERS" <<EOF
+# Orion Belt images on GitHub Container Registry (multi-arch amd64/arm64).
+# Documented here for the packages mirror; images are published on release.
+#
+#   docker pull ${SERVER_IMG}:${VER}
+#   docker pull ${AGENT_IMG}:${VER}
+#
+${SERVER_IMG}:${VER}
+${SERVER_IMG}:${TAG}
+${SERVER_IMG}:latest
+${AGENT_IMG}:${VER}
+${AGENT_IMG}:${TAG}
+${AGENT_IMG}:latest
+EOF
+
 cat >"$OUT/index.html" <<EOF
 <!DOCTYPE html>
 <html lang="en">
@@ -184,16 +205,22 @@ cat >"$OUT/index.html" <<EOF
     body { font-family: ui-sans-serif, system-ui, sans-serif; max-width: 52rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; color: #111; }
     code { background: #f4f4f5; padding: 0.1em 0.35em; border-radius: 4px; }
     a { color: #0b57d0; }
+    pre { background: #f4f4f5; padding: 0.75rem 1rem; overflow-x: auto; border-radius: 6px; }
   </style>
 </head>
 <body>
   <h1>Orion Belt packages</h1>
   <p>Static package mirror for <strong>Add agent</strong> install scripts.</p>
   <p>Package base URL: <code>${PAGES_URL}</code></p>
-  <p>Current release: <a href="VERSION">VERSION</a> / <a href="TAG">TAG</a> (${VER}).</p>
+  <p>Current release: <a href="VERSION">VERSION</a> / <a href="TAG">TAG</a> (${VER}).
+     The console reads <code>VERSION</code> to prefill Package version.</p>
   <p>Filenames match the install script
      (<code>orion-belt-agent_\${VERSION}_amd64.deb</code>, etc.)
      plus GoReleaser originals (<code>*_linux_amd64.*</code>).</p>
+  <h2>Container images (GHCR)</h2>
+  <p>See <a href="CONTAINERS">CONTAINERS</a>. Pull:</p>
+  <pre>docker pull ${SERVER_IMG}:${VER}
+docker pull ${AGENT_IMG}:${VER}</pre>
   <p>Source: <a href="https://github.com/orion-belt-dev/orion-belt/releases">GitHub Releases</a>.
      Repo: <a href="https://github.com/${REPO_SLUG}">${REPO_SLUG}</a>.
      Local mirror: <code>make serve-packages</code>.</p>
@@ -214,9 +241,31 @@ WORKDIR="$(mktemp -d)"
 cleanup() { rm -rf "$WORKDIR"; }
 trap cleanup EXIT
 
-echo "==> Pushing to ${REPO_SLUG} (gh-pages)"
-git clone --branch gh-pages --single-branch "git@github.com:${REPO_SLUG}.git" "$WORKDIR/repo" \
-  || git clone "git@github.com:${REPO_SLUG}.git" "$WORKDIR/repo"
+# Auth for cross-repo push (orion-belt → orion-belt-dev/packages):
+#   ORION_PACKAGES_TOKEN / PACKAGES_TOKEN  — HTTPS PAT with contents:write on packages
+#   PACKAGES_DEPLOY_KEY                   — SSH deploy key (write) on packages
+TOKEN="${ORION_PACKAGES_TOKEN:-${PACKAGES_TOKEN:-}}"
+DEPLOY_KEY="${PACKAGES_DEPLOY_KEY:-}"
+
+CLONE_URL=""
+if [[ -n "$TOKEN" ]]; then
+  CLONE_URL="https://x-access-token:${TOKEN}@github.com/${REPO_SLUG}.git"
+  echo "==> Pushing to ${REPO_SLUG} (gh-pages) via HTTPS token"
+elif [[ -n "$DEPLOY_KEY" ]]; then
+  eval "$(ssh-agent -s)" >/dev/null
+  echo "$DEPLOY_KEY" | tr -d '\r' | ssh-add -
+  mkdir -p ~/.ssh
+  chmod 700 ~/.ssh
+  ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null || true
+  CLONE_URL="git@github.com:${REPO_SLUG}.git"
+  echo "==> Pushing to ${REPO_SLUG} (gh-pages) via SSH deploy key"
+else
+  die "PUSH=1 requires ORION_PACKAGES_TOKEN (or PACKAGES_TOKEN) or PACKAGES_DEPLOY_KEY
+  Set a repo/org secret with write access to ${REPO_SLUG}, then re-run the Release workflow."
+fi
+
+git clone --branch gh-pages --single-branch "$CLONE_URL" "$WORKDIR/repo" \
+  || git clone "$CLONE_URL" "$WORKDIR/repo"
 
 cd "$WORKDIR/repo"
 if ! git rev-parse --verify gh-pages >/dev/null 2>&1; then

--- a/scripts/serve-packages.sh
+++ b/scripts/serve-packages.sh
@@ -36,6 +36,18 @@ if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
 fi
 
 BIND="${ORION_PKG_BIND:-0.0.0.0}"
+
+# Ensure VERSION exists so Add-agent can discover the package version locally.
+if [[ ! -f "$DIST/VERSION" ]]; then
+  ver="${VERSION:-$(git -C "$ROOT" describe --tags --abbrev=0 2>/dev/null || true)}"
+  ver="${ver#v}"
+  if [[ -z "$ver" || "$ver" == "dev" ]]; then
+    ver="0.0.0"
+  fi
+  printf '%s\n' "$ver" >"$DIST/VERSION"
+  echo "Wrote $DIST/VERSION ($ver)"
+fi
+
 echo "Serving $DIST at http://${BIND}:$PORT/"
 echo "Add agent → Package base URL: http://127.0.0.1:$PORT  (or http://<host-ip>:$PORT)"
 echo "Ctrl-C to stop."

--- a/web/ui/src/pages/AddAgentPage.tsx
+++ b/web/ui/src/pages/AddAgentPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { FormEvent } from "react";
 import { api } from "../lib/api";
 import { useToast } from "../components/Toast";
@@ -15,8 +15,29 @@ import logoLinux from "../assets/distros/linux.png";
 
 /** Public GitHub Pages mirror (orion-belt-dev/packages). Local: make serve-packages → :8765 */
 const DEFAULT_PACKAGE_BASE_URL = "https://orion-belt-dev.github.io/packages";
-/** Matches the seeded Pages release when the gateway build is untagged/dev. */
-const DEFAULT_PACKAGE_VERSION = "1.0.0";
+/** Fallback only until VERSION is fetched from the package base URL. */
+const DEFAULT_PACKAGE_VERSION = "1.1.0";
+
+function normalizePackageVersion(raw: string): string {
+  let v = String(raw || "").trim();
+  if (v.startsWith("v")) v = v.slice(1);
+  return v;
+}
+
+/** Read `${base}/VERSION` from the package mirror (Pages or local serve). */
+async function fetchPackageVersion(baseUrl: string): Promise<string | null> {
+  const base = baseUrl.replace(/\/+$/, "");
+  if (!base) return null;
+  try {
+    const res = await fetch(`${base}/VERSION`, { cache: "no-cache" });
+    if (!res.ok) return null;
+    const v = normalizePackageVersion(await res.text());
+    if (!v || v === "dev" || v === "0.0.0") return null;
+    return v;
+  } catch {
+    return null;
+  }
+}
 
 const OS_OPTIONS = [
   {
@@ -75,16 +96,34 @@ export function AddAgentPage() {
   const [gwPort, setGwPort] = useState(2222);
   const [pkg, setPkg] = useState(DEFAULT_PACKAGE_BASE_URL);
   const [ver, setVer] = useState(() => {
-    let v = version?.version || version?.display || DEFAULT_PACKAGE_VERSION;
-    if (String(v).startsWith("v")) v = String(v).slice(1);
-    if (v === "dev" || v === "0.0.0") v = DEFAULT_PACKAGE_VERSION;
-    return String(v);
+    let v = normalizePackageVersion(version?.version || version?.display || "");
+    if (!v || v === "dev" || v === "0.0.0") v = DEFAULT_PACKAGE_VERSION;
+    return v;
   });
+  const [verSource, setVerSource] = useState<"mirror" | "manual" | "fallback">("fallback");
   const [script, setScript] = useState("");
   const [filename, setFilename] = useState("orion-belt-install-agent.sh");
   const [msg, setMsg] = useState("");
   const [err, setErr] = useState("");
   const [busy, setBusy] = useState(false);
+
+  // Prefer the package mirror's VERSION so Add-agent tracks the published
+  // release even when this gateway binary is an untagged/dev build.
+  useEffect(() => {
+    let cancelled = false;
+    const base = pkg.trim() || DEFAULT_PACKAGE_BASE_URL;
+    const timer = window.setTimeout(() => {
+      fetchPackageVersion(base).then((remote) => {
+        if (cancelled || !remote) return;
+        setVer(remote);
+        setVerSource("mirror");
+      });
+    }, 300);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [pkg]);
 
   const selected = OS_OPTIONS.find((o) => o.id === os) || OS_OPTIONS[0];
 
@@ -186,10 +225,26 @@ export function AddAgentPage() {
               onChange={(e) => setPkg(e.target.value)}
               placeholder={DEFAULT_PACKAGE_BASE_URL}
             />
+            <p className="muted" style={{ margin: "0.35rem 0 0", fontSize: "0.85em" }}>
+              Default: public Pages mirror. Local build:{" "}
+              <code>make packages &amp;&amp; make serve-packages</code> →{" "}
+              <code>http://127.0.0.1:8765</code>
+            </p>
           </div>
           <div>
             <label className="field">Package version</label>
-            <input value={ver} onChange={(e) => setVer(e.target.value)} />
+            <input
+              value={ver}
+              onChange={(e) => {
+                setVer(e.target.value);
+                setVerSource("manual");
+              }}
+            />
+            <p className="muted" style={{ margin: "0.35rem 0 0", fontSize: "0.85em" }}>
+              {verSource === "mirror"
+                ? "Loaded from package mirror VERSION"
+                : "Edit freely — mirror VERSION used when available"}
+            </p>
           </div>
         </div>
         {err ? <div className="err">{err}</div> : null}


### PR DESCRIPTION
## Summary
- Push multi-arch `orion-belt-server` / `orion-belt-agent` images to GHCR on Release (`:version`, `:v*`, `:latest`).
- Make packages Pages publish part of Release via `make publish-packages-pages … PUSH=1` (requires `PACKAGES_TOKEN` or `PACKAGES_DEPLOY_KEY`; fails loudly if missing).
- Add-agent loads Package version from `https://orion-belt-dev.github.io/packages/VERSION`.
- Add `docker-compose.prod.yml` / `docker-compose.prod.agent.yml` with `pull_policy: always` on GHCR `:latest` (`make docker-prod-up`).

## Test plan
- [x] Add-agent at `/ui/add-agent` shows version matching Pages `VERSION` (rebuild UI)
- [x] Release (or dry-run script) builds `packages-site/` and pushes when `PACKAGES_TOKEN` is set
- [x] `cp .env.prod.example .env.prod` → `make docker-prod-up` pulls `ghcr.io/orion-belt-dev/orion-belt-server:latest`
- [x] Optional: `make docker-prod-agent-up` with a registered agent key
- [x] Pin check: `ORION_IMAGE_TAG=1.1.0 make docker-prod-up`