### PR TITLE
Fix agent/user hard-delete FK blocks and schema repair on startup

### DIFF
--- a/cmd/server/agent.go
+++ b/cmd/server/agent.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/orion-belt-dev/orion-belt/pkg/ca"
 	"github.com/orion-belt-dev/orion-belt/pkg/common"
-	"github.com/orion-belt-dev/orion-belt/pkg/database"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
 )
@@ -74,14 +73,10 @@ func runAgentRegister(cmd *cobra.Command, args []string) {
 		logger.Fatal("Failed to load config: %v", err)
 	}
 
-	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
-	if err != nil {
-		logger.Fatal("Failed to create database store: %v", err)
-	}
-
 	ctx := context.Background()
-	if err := store.Connect(ctx); err != nil {
-		logger.Fatal("Failed to connect to database: %v", err)
+	store, err := openStore(ctx)
+	if err != nil {
+		logger.Fatal("%v", err)
 	}
 	defer store.Close()
 
@@ -179,19 +174,10 @@ func runAgentRegister(cmd *cobra.Command, args []string) {
 
 func runAgentList(cmd *cobra.Command, args []string) {
 	logger := getLogger()
-	config, err := loadConfig()
-	if err != nil {
-		logger.Fatal("Failed to load config: %v", err)
-	}
-
-	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
-	if err != nil {
-		logger.Fatal("Failed to create database store: %v", err)
-	}
-
 	ctx := context.Background()
-	if err := store.Connect(ctx); err != nil {
-		logger.Fatal("Failed to connect to database: %v", err)
+	store, err := openStore(ctx)
+	if err != nil {
+		logger.Fatal("%v", err)
 	}
 	defer store.Close()
 
@@ -238,19 +224,10 @@ func runAgentList(cmd *cobra.Command, args []string) {
 func runAgentDelete(cmd *cobra.Command, args []string) {
 	agentName := args[0]
 	logger := getLogger()
-	config, err := loadConfig()
-	if err != nil {
-		logger.Fatal("Failed to load config: %v", err)
-	}
-
-	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
-	if err != nil {
-		logger.Fatal("Failed to create database store: %v", err)
-	}
-
 	ctx := context.Background()
-	if err := store.Connect(ctx); err != nil {
-		logger.Fatal("Failed to connect to database: %v", err)
+	store, err := openStore(ctx)
+	if err != nil {
+		logger.Fatal("%v", err)
 	}
 	defer store.Close()
 

--- a/cmd/server/permission.go
+++ b/cmd/server/permission.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/orion-belt-dev/orion-belt/pkg/auth"
 	"github.com/orion-belt-dev/orion-belt/pkg/common"
-	"github.com/orion-belt-dev/orion-belt/pkg/database"
 	"github.com/spf13/cobra"
 )
 
@@ -79,11 +78,6 @@ func init() {
 
 func runPermGrant(cmd *cobra.Command, args []string) {
 	logger := getLogger()
-	config, err := loadConfig()
-	if err != nil {
-		logger.Fatal("Failed to load config: %v", err)
-	}
-
 	// Validate access type
 	if permAccessType != "ssh" && permAccessType != "scp" && permAccessType != "both" {
 		logger.Fatal("Invalid access type '%s'. Must be 'ssh', 'scp', or 'both'", permAccessType)
@@ -105,15 +99,10 @@ func runPermGrant(cmd *cobra.Command, args []string) {
 		remoteUsers = []string{"root"} // default
 	}
 
-	// Initialize database
-	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
-	if err != nil {
-		logger.Fatal("Failed to create database store: %v", err)
-	}
-
 	ctx := context.Background()
-	if err := store.Connect(ctx); err != nil {
-		logger.Fatal("Failed to connect to database: %v", err)
+	store, err := openStore(ctx)
+	if err != nil {
+		logger.Fatal("%v", err)
 	}
 	defer store.Close()
 
@@ -201,20 +190,10 @@ func runPermGrant(cmd *cobra.Command, args []string) {
 
 func runPermList(cmd *cobra.Command, args []string) {
 	logger := getLogger()
-	config, err := loadConfig()
-	if err != nil {
-		logger.Fatal("Failed to load config: %v", err)
-	}
-
-	// Initialize database
-	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
-	if err != nil {
-		logger.Fatal("Failed to create database store: %v", err)
-	}
-
 	ctx := context.Background()
-	if err := store.Connect(ctx); err != nil {
-		logger.Fatal("Failed to connect to database: %v", err)
+	store, err := openStore(ctx)
+	if err != nil {
+		logger.Fatal("%v", err)
 	}
 	defer store.Close()
 
@@ -273,20 +252,10 @@ func runPermList(cmd *cobra.Command, args []string) {
 
 func runSessionList(cmd *cobra.Command, args []string) {
 	logger := getLogger()
-	config, err := loadConfig()
-	if err != nil {
-		logger.Fatal("Failed to load config: %v", err)
-	}
-
-	// Initialize database
-	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
-	if err != nil {
-		logger.Fatal("Failed to create database store: %v", err)
-	}
-
 	ctx := context.Background()
-	if err := store.Connect(ctx); err != nil {
-		logger.Fatal("Failed to connect to database: %v", err)
+	store, err := openStore(ctx)
+	if err != nil {
+		logger.Fatal("%v", err)
 	}
 	defer store.Close()
 

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/orion-belt-dev/orion-belt/pkg/common"
-	"github.com/orion-belt-dev/orion-belt/pkg/database"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
 )
@@ -59,17 +58,11 @@ func runSetup(cmd *cobra.Command, args []string) {
 		fmt.Printf("  %s\n", configPath)
 	}
 
-	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
+	store, err := openStore(cmd.Context())
 	if err != nil {
 		logger.Fatal("Database: %v\n  Ensure Postgres is up and connection_string is correct.", err)
 	}
 	defer store.Close()
-	if err := store.Connect(cmd.Context()); err != nil {
-		logger.Fatal("Database connect: %v", err)
-	}
-	if err := store.Migrate(cmd.Context()); err != nil {
-		logger.Fatal("Database migrate: %v", err)
-	}
 	fmt.Println("✓ Database reachable (schema up to date)")
 
 	fmt.Println()

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/orion-belt-dev/orion-belt/pkg/database"
+)
+
+// openStore connects to the configured database and runs Migrate/repair so CLI
+// mutations see the same schema the gateway would after startup.
+func openStore(ctx context.Context) (database.Store, error) {
+	config, err := loadConfig()
+	if err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
+	if err != nil {
+		return nil, fmt.Errorf("database: %w", err)
+	}
+	if err := store.Connect(ctx); err != nil {
+		_ = store.Close()
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	if err := store.Migrate(ctx); err != nil {
+		_ = store.Close()
+		return nil, fmt.Errorf("migrate/repair: %w", err)
+	}
+	return store, nil
+}

--- a/cmd/server/user.go
+++ b/cmd/server/user.go
@@ -8,7 +8,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/orion-belt-dev/orion-belt/pkg/common"
-	"github.com/orion-belt-dev/orion-belt/pkg/database"
 	"github.com/spf13/cobra"
 )
 
@@ -67,20 +66,10 @@ func init() {
 
 func runUserCreate(cmd *cobra.Command, args []string) {
 	logger := getLogger()
-	config, err := loadConfig()
-	if err != nil {
-		logger.Fatal("Failed to load config: %v", err)
-	}
-
-	// Initialize database
-	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
-	if err != nil {
-		logger.Fatal("Failed to create database store: %v", err)
-	}
-
 	ctx := context.Background()
-	if err := store.Connect(ctx); err != nil {
-		logger.Fatal("Failed to connect to database: %v", err)
+	store, err := openStore(ctx)
+	if err != nil {
+		logger.Fatal("%v", err)
 	}
 	defer store.Close()
 
@@ -113,20 +102,10 @@ func runUserCreate(cmd *cobra.Command, args []string) {
 
 func runUserList(cmd *cobra.Command, args []string) {
 	logger := getLogger()
-	config, err := loadConfig()
-	if err != nil {
-		logger.Fatal("Failed to load config: %v", err)
-	}
-
-	// Initialize database
-	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
-	if err != nil {
-		logger.Fatal("Failed to create database store: %v", err)
-	}
-
 	ctx := context.Background()
-	if err := store.Connect(ctx); err != nil {
-		logger.Fatal("Failed to connect to database: %v", err)
+	store, err := openStore(ctx)
+	if err != nil {
+		logger.Fatal("%v", err)
 	}
 	defer store.Close()
 
@@ -163,20 +142,10 @@ func runUserList(cmd *cobra.Command, args []string) {
 func runUserDelete(cmd *cobra.Command, args []string) {
 	username := args[0]
 	logger := getLogger()
-	config, err := loadConfig()
-	if err != nil {
-		logger.Fatal("Failed to load config: %v", err)
-	}
-
-	// Initialize database
-	store, err := database.NewStore(config.Database.Driver, config.Database.ConnectionString)
-	if err != nil {
-		logger.Fatal("Failed to create database store: %v", err)
-	}
-
 	ctx := context.Background()
-	if err := store.Connect(ctx); err != nil {
-		logger.Fatal("Failed to connect to database: %v", err)
+	store, err := openStore(ctx)
+	if err != nil {
+		logger.Fatal("%v", err)
 	}
 	defer store.Close()
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1104,9 +1104,35 @@ func (s *APIServer) deleteMachine(c *gin.Context) {
 		return
 	}
 
+	// Best-effort: gather recording paths before cascading session rows away.
+	recordingPaths, _ := s.store.ListSessionRecordingPathsForMachine(ctx, id)
+
+	if s.agentCommander != nil {
+		_ = s.agentCommander.DisconnectAgent(id)
+	}
+
+	agentUserID := machine.AgentID
+
 	if err := s.store.DeleteMachine(ctx, id); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
+	}
+	if agentUserID != "" {
+		if err := s.store.DeleteUser(ctx, agentUserID); err != nil && err != database.ErrNotFound {
+			if s.logger != nil {
+				s.logger.Warn("deleted machine %s but failed to remove agent user %s: %v", id, agentUserID, err)
+			}
+		}
+	}
+	for _, path := range recordingPaths {
+		if path == "" {
+			continue
+		}
+		_ = os.Remove(path)
+		_ = os.Remove(path + ".enc")
+		if strings.HasSuffix(path, ".cast") {
+			_ = os.Remove(path + ".gz")
+		}
 	}
 	s.recordAudit(c, "machine.delete", "machine:"+id, map[string]interface{}{"name": machine.Name})
 	c.JSON(http.StatusOK, gin.H{"message": "machine deleted"})

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -79,8 +79,8 @@ func (s *PostgresStore) Migrate(ctx context.Context) error {
 		)`,
 		`CREATE TABLE IF NOT EXISTS sessions (
 			id VARCHAR(36) PRIMARY KEY,
-			user_id VARCHAR(36) NOT NULL REFERENCES users(id),
-			machine_id VARCHAR(36) NOT NULL REFERENCES machines(id),
+			user_id VARCHAR(36) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			machine_id VARCHAR(36) NOT NULL REFERENCES machines(id) ON DELETE CASCADE,
 			remote_user VARCHAR(255) NOT NULL,
 			source VARCHAR(32) NOT NULL DEFAULT 'ssh',
 			start_time TIMESTAMP NOT NULL,
@@ -91,8 +91,8 @@ func (s *PostgresStore) Migrate(ctx context.Context) error {
 		)`,
 		`CREATE TABLE IF NOT EXISTS access_requests (
 			id VARCHAR(36) PRIMARY KEY,
-			user_id VARCHAR(36) NOT NULL REFERENCES users(id),
-			machine_id VARCHAR(36) NOT NULL REFERENCES machines(id),
+			user_id VARCHAR(36) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			machine_id VARCHAR(36) NOT NULL REFERENCES machines(id) ON DELETE CASCADE,
 			remote_users TEXT[] NOT NULL,
 			access_type VARCHAR(50) NOT NULL DEFAULT 'both',
 			reason TEXT NOT NULL,
@@ -100,22 +100,22 @@ func (s *PostgresStore) Migrate(ctx context.Context) error {
 			status VARCHAR(50) NOT NULL,
 			requested_at TIMESTAMP NOT NULL,
 			reviewed_at TIMESTAMP,
-			reviewed_by VARCHAR(36) REFERENCES users(id),
+			reviewed_by VARCHAR(36) REFERENCES users(id) ON DELETE SET NULL,
 			expires_at TIMESTAMP
 		)`,
 		`CREATE TABLE IF NOT EXISTS permissions (
 			id VARCHAR(36) PRIMARY KEY,
-			user_id VARCHAR(36) NOT NULL REFERENCES users(id),
-			machine_id VARCHAR(36) NOT NULL REFERENCES machines(id),
+			user_id VARCHAR(36) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			machine_id VARCHAR(36) NOT NULL REFERENCES machines(id) ON DELETE CASCADE,
 			access_type VARCHAR(50) NOT NULL,
 			remote_users TEXT[] NOT NULL,
-			granted_by VARCHAR(36) NOT NULL REFERENCES users(id),
+			granted_by VARCHAR(36) REFERENCES users(id) ON DELETE SET NULL,
 			granted_at TIMESTAMP NOT NULL,
 			expires_at TIMESTAMP
 		)`,
 		`CREATE TABLE IF NOT EXISTS audit_logs (
 			id VARCHAR(36) PRIMARY KEY,
-			user_id VARCHAR(36) REFERENCES users(id),
+			user_id VARCHAR(36) REFERENCES users(id) ON DELETE SET NULL,
 			action VARCHAR(255) NOT NULL,
 			resource VARCHAR(255) NOT NULL,
 			metadata JSONB,
@@ -260,7 +260,7 @@ func (s *PostgresStore) Migrate(ctx context.Context) error {
 			issued_at TIMESTAMP NOT NULL,
 			expires_at TIMESTAMP NOT NULL,
 			revoked_at TIMESTAMP,
-			revoked_by VARCHAR(36) REFERENCES users(id),
+			revoked_by VARCHAR(36) REFERENCES users(id) ON DELETE SET NULL,
 			revoke_reason TEXT
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_ssh_certificates_subject ON ssh_certificates(subject_id)`,
@@ -274,7 +274,202 @@ func (s *PostgresStore) Migrate(ctx context.Context) error {
 		}
 	}
 
+	// Repair FK / nullability drift on upgraded databases (idempotent; no-op when OK).
+	if err := s.repairSchema(ctx); err != nil {
+		return fmt.Errorf("%w: %v", ErrMigrationFailed, err)
+	}
+
 	return nil
+}
+
+// fkSpec describes the foreign key we want after repair.
+type fkSpec struct {
+	table     string
+	column    string
+	refTable  string
+	refColumn string
+	onDelete  string // CASCADE | SET NULL | NO ACTION | RESTRICT
+	name      string // preferred constraint name
+}
+
+// repairSchema brings an existing database in line with the delete/nullability
+// rules this build expects. Fresh CREATE TABLE IF NOT EXISTS leaves old FKs
+// alone; without this step agent/user deletes fail with 23503 after real use.
+func (s *PostgresStore) repairSchema(ctx context.Context) error {
+	if err := s.ensureColumnNullable(ctx, "permissions", "granted_by"); err != nil {
+		return err
+	}
+
+	specs := []fkSpec{
+		{"sessions", "machine_id", "machines", "id", "CASCADE", "sessions_machine_id_fkey"},
+		{"sessions", "user_id", "users", "id", "CASCADE", "sessions_user_id_fkey"},
+		{"access_requests", "machine_id", "machines", "id", "CASCADE", "access_requests_machine_id_fkey"},
+		{"access_requests", "user_id", "users", "id", "CASCADE", "access_requests_user_id_fkey"},
+		{"access_requests", "reviewed_by", "users", "id", "SET NULL", "access_requests_reviewed_by_fkey"},
+		{"permissions", "machine_id", "machines", "id", "CASCADE", "permissions_machine_id_fkey"},
+		{"permissions", "user_id", "users", "id", "CASCADE", "permissions_user_id_fkey"},
+		{"permissions", "granted_by", "users", "id", "SET NULL", "permissions_granted_by_fkey"},
+		{"audit_logs", "user_id", "users", "id", "SET NULL", "audit_logs_user_id_fkey"},
+		{"ssh_certificates", "revoked_by", "users", "id", "SET NULL", "ssh_certificates_revoked_by_fkey"},
+		{"api_keys", "user_id", "users", "id", "CASCADE", "api_keys_user_id_fkey"},
+		{"http_sessions", "user_id", "users", "id", "CASCADE", "http_sessions_user_id_fkey"},
+		{"user_ssh_keys", "user_id", "users", "id", "CASCADE", "user_ssh_keys_user_id_fkey"},
+		{"webauthn_credentials", "user_id", "users", "id", "CASCADE", "webauthn_credentials_user_id_fkey"},
+		{"notification_prefs", "user_id", "users", "id", "CASCADE", "notification_prefs_user_id_fkey"},
+		{"notifications", "user_id", "users", "id", "CASCADE", "notifications_user_id_fkey"},
+	}
+	for _, spec := range specs {
+		if err := s.ensureForeignKey(ctx, spec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizeDeleteRule(rule string) string {
+	switch strings.ToUpper(strings.TrimSpace(rule)) {
+	case "CASCADE":
+		return "CASCADE"
+	case "SET NULL":
+		return "SET NULL"
+	case "SET DEFAULT":
+		return "SET DEFAULT"
+	case "RESTRICT":
+		return "RESTRICT"
+	default:
+		return "NO ACTION"
+	}
+}
+
+func (s *PostgresStore) ensureColumnNullable(ctx context.Context, table, column string) error {
+	var nullable string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT is_nullable
+		FROM information_schema.columns
+		WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2`,
+		table, column).Scan(&nullable)
+	if err == sql.ErrNoRows {
+		return nil // table/column not present yet
+	}
+	if err != nil {
+		return fmt.Errorf("inspect %s.%s nullability: %w", table, column, err)
+	}
+	if strings.EqualFold(nullable, "YES") {
+		return nil
+	}
+	_, err = s.db.ExecContext(ctx, fmt.Sprintf(
+		`ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL`,
+		pqQuoteIdent(table), pqQuoteIdent(column)))
+	if err != nil {
+		return fmt.Errorf("make %s.%s nullable: %w", table, column, err)
+	}
+	return nil
+}
+
+type existingFK struct {
+	name       string
+	deleteRule string
+	refTable   string
+	refColumn  string
+}
+
+func (s *PostgresStore) listForeignKeys(ctx context.Context, table, column string) ([]existingFK, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT tc.constraint_name, rc.delete_rule, ccu.table_name, ccu.column_name
+		FROM information_schema.table_constraints AS tc
+		JOIN information_schema.key_column_usage AS kcu
+		  ON tc.constraint_name = kcu.constraint_name
+		 AND tc.table_schema = kcu.table_schema
+		JOIN information_schema.referential_constraints AS rc
+		  ON tc.constraint_name = rc.constraint_name
+		 AND tc.table_schema = rc.constraint_schema
+		JOIN information_schema.constraint_column_usage AS ccu
+		  ON ccu.constraint_name = tc.constraint_name
+		 AND ccu.table_schema = tc.table_schema
+		WHERE tc.constraint_type = 'FOREIGN KEY'
+		  AND tc.table_schema = 'public'
+		  AND tc.table_name = $1
+		  AND kcu.column_name = $2`, table, column)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []existingFK
+	for rows.Next() {
+		var fk existingFK
+		if err := rows.Scan(&fk.name, &fk.deleteRule, &fk.refTable, &fk.refColumn); err != nil {
+			return nil, err
+		}
+		fk.deleteRule = normalizeDeleteRule(fk.deleteRule)
+		out = append(out, fk)
+	}
+	return out, rows.Err()
+}
+
+func (s *PostgresStore) ensureForeignKey(ctx context.Context, spec fkSpec) error {
+	want := normalizeDeleteRule(spec.onDelete)
+	existing, err := s.listForeignKeys(ctx, spec.table, spec.column)
+	if err != nil {
+		return fmt.Errorf("inspect FK %s.%s: %w", spec.table, spec.column, err)
+	}
+
+	ok := false
+	if len(existing) == 1 {
+		fk := existing[0]
+		if fk.deleteRule == want && fk.refTable == spec.refTable && fk.refColumn == spec.refColumn {
+			ok = true
+		}
+	}
+	if ok {
+		return nil
+	}
+
+	for _, fk := range existing {
+		if _, err := s.db.ExecContext(ctx, fmt.Sprintf(
+			`ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s`,
+			pqQuoteIdent(spec.table), pqQuoteIdent(fk.name))); err != nil {
+			return fmt.Errorf("drop FK %s: %w", fk.name, err)
+		}
+	}
+
+	// Also drop the preferred name in case it exists on another column shape.
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(
+		`ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s`,
+		pqQuoteIdent(spec.table), pqQuoteIdent(spec.name))); err != nil {
+		return fmt.Errorf("drop FK %s: %w", spec.name, err)
+	}
+
+	onDeleteSQL := "NO ACTION"
+	switch want {
+	case "CASCADE":
+		onDeleteSQL = "CASCADE"
+	case "SET NULL":
+		onDeleteSQL = "SET NULL"
+	case "SET DEFAULT":
+		onDeleteSQL = "SET DEFAULT"
+	case "RESTRICT":
+		onDeleteSQL = "RESTRICT"
+	}
+
+	_, err = s.db.ExecContext(ctx, fmt.Sprintf(
+		`ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s(%s) ON DELETE %s`,
+		pqQuoteIdent(spec.table),
+		pqQuoteIdent(spec.name),
+		pqQuoteIdent(spec.column),
+		pqQuoteIdent(spec.refTable),
+		pqQuoteIdent(spec.refColumn),
+		onDeleteSQL,
+	))
+	if err != nil {
+		return fmt.Errorf("add FK %s: %w", spec.name, err)
+	}
+	return nil
+}
+
+// pqQuoteIdent quotes a SQL identifier (table/column/constraint) safely.
+func pqQuoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
 // CreateUser creates a new user
@@ -374,18 +569,55 @@ func (s *PostgresStore) UpdateUser(ctx context.Context, user *common.User) error
 	return nil
 }
 
-// DeleteUser deletes a user
+// DeleteUser deletes a user and dependent subject rows (sessions, their
+// access requests, their permissions). Attribution FKs (granted_by,
+// reviewed_by, audit_logs.user_id, revoked_by) are nulled so history for
+// other principals is preserved. Credential tables already CASCADE.
 func (s *PostgresStore) DeleteUser(ctx context.Context, id string) error {
-	query := `DELETE FROM users WHERE id = $1`
-	result, err := s.db.ExecContext(ctx, query, id)
-
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete user: %w", err)
 	}
+	defer func() { _ = tx.Rollback() }()
 
+	// Clear attribution pointers first (works even before SET NULL migrations).
+	if _, err := tx.ExecContext(ctx, `UPDATE permissions SET granted_by = NULL WHERE granted_by = $1`, id); err != nil {
+		// Pre-migration schemas still have granted_by NOT NULL — point at the
+		// permission subject so the row can survive until migrate rebinds the FK.
+		if _, err2 := tx.ExecContext(ctx, `UPDATE permissions SET granted_by = user_id WHERE granted_by = $1`, id); err2 != nil {
+			return fmt.Errorf("failed to clear permission grantor: %w", err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE access_requests SET reviewed_by = NULL WHERE reviewed_by = $1`, id); err != nil {
+		return fmt.Errorf("failed to clear access-request reviewer: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE audit_logs SET user_id = NULL WHERE user_id = $1`, id); err != nil {
+		return fmt.Errorf("failed to clear audit log user: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE ssh_certificates SET revoked_by = NULL WHERE revoked_by = $1`, id); err != nil {
+		return fmt.Errorf("failed to clear certificate revoker: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM permissions WHERE user_id = $1`, id); err != nil {
+		return fmt.Errorf("failed to delete user permissions: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM access_requests WHERE user_id = $1`, id); err != nil {
+		return fmt.Errorf("failed to delete user access requests: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM sessions WHERE user_id = $1`, id); err != nil {
+		return fmt.Errorf("failed to delete user sessions: %w", err)
+	}
+
+	result, err := tx.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete user: %w", err)
+	}
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
 		return ErrNotFound
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to delete user: %w", err)
 	}
 	return nil
 }
@@ -504,20 +736,61 @@ func (s *PostgresStore) UpdateMachine(ctx context.Context, machine *common.Machi
 	return nil
 }
 
-// DeleteMachine deletes a machine
+// DeleteMachine deletes a machine and its dependent rows (permissions,
+// access requests, and sessions). Session recording files on disk are left for
+// the retention job / operator cleanup — the FK cascade is what unblocks UI delete.
 func (s *PostgresStore) DeleteMachine(ctx context.Context, id string) error {
-	query := `DELETE FROM machines WHERE id = $1`
-	result, err := s.db.ExecContext(ctx, query, id)
-
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete machine: %w", err)
 	}
+	defer func() { _ = tx.Rollback() }()
 
+	// Explicit deletes keep behaviour correct even before the CASCADE migration
+	// has run on an upgraded database.
+	if _, err := tx.ExecContext(ctx, `DELETE FROM permissions WHERE machine_id = $1`, id); err != nil {
+		return fmt.Errorf("failed to delete machine permissions: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM access_requests WHERE machine_id = $1`, id); err != nil {
+		return fmt.Errorf("failed to delete machine access requests: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM sessions WHERE machine_id = $1`, id); err != nil {
+		return fmt.Errorf("failed to delete machine sessions: %w", err)
+	}
+
+	result, err := tx.ExecContext(ctx, `DELETE FROM machines WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete machine: %w", err)
+	}
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
 		return ErrNotFound
 	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to delete machine: %w", err)
+	}
 	return nil
+}
+
+// ListSessionRecordingPathsForMachine returns recording_path values for a machine.
+func (s *PostgresStore) ListSessionRecordingPathsForMachine(ctx context.Context, machineID string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT recording_path FROM sessions WHERE machine_id = $1 AND recording_path <> ''`, machineID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list session recordings: %w", err)
+	}
+	defer rows.Close()
+	var paths []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, fmt.Errorf("failed to scan recording path: %w", err)
+		}
+		if p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths, rows.Err()
 }
 
 // ListMachines lists machines with pagination

--- a/pkg/database/repair_test.go
+++ b/pkg/database/repair_test.go
@@ -1,0 +1,31 @@
+package database
+
+import "testing"
+
+func TestNormalizeDeleteRule(t *testing.T) {
+	cases := map[string]string{
+		"CASCADE":     "CASCADE",
+		"cascade":     "CASCADE",
+		"SET NULL":    "SET NULL",
+		"set null":    "SET NULL",
+		"SET DEFAULT": "SET DEFAULT",
+		"RESTRICT":    "RESTRICT",
+		"NO ACTION":   "NO ACTION",
+		"":            "NO ACTION",
+		"  ":          "NO ACTION",
+	}
+	for in, want := range cases {
+		if got := normalizeDeleteRule(in); got != want {
+			t.Errorf("normalizeDeleteRule(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestPqQuoteIdent(t *testing.T) {
+	if got := pqQuoteIdent(`sessions`); got != `"sessions"` {
+		t.Errorf("got %s", got)
+	}
+	if got := pqQuoteIdent(`weird"name`); got != `"weird""name"` {
+		t.Errorf("got %s", got)
+	}
+}

--- a/pkg/database/store.go
+++ b/pkg/database/store.go
@@ -26,6 +26,9 @@ type Store interface {
 	DeleteMachine(ctx context.Context, id string) error
 	ListMachines(ctx context.Context, limit, offset int) ([]*common.Machine, error)
 	ListActiveMachines(ctx context.Context) ([]*common.Machine, error)
+	// ListSessionRecordingPathsForMachine returns on-disk recording paths for
+	// sessions tied to machineID (used to clean files after hard-delete).
+	ListSessionRecordingPathsForMachine(ctx context.Context, machineID string) ([]string, error)
 
 	// Session operations
 	CreateSession(ctx context.Context, session *common.Session) error

--- a/web/ui/src/pages/AgentsPage.tsx
+++ b/web/ui/src/pages/AgentsPage.tsx
@@ -154,7 +154,13 @@ export function AgentsPage() {
       toast("Delete is only allowed after revoke (or archive)", "err");
       return;
     }
-    if (!confirm(`Permanently delete ${m.name}?`)) return;
+    if (
+      !confirm(
+        `Permanently delete ${m.name}?\n\nThis removes related permissions, access requests, session history, and recordings for this agent.\n\nIf you need to keep those records, cancel and Archive the agent instead.`,
+      )
+    ) {
+      return;
+    }
     try {
       await api(`/admin/machines/${encodeURIComponent(m.id)}`, { method: "DELETE" });
       toast("Agent deleted");

--- a/web/ui/src/pages/UsersPage.tsx
+++ b/web/ui/src/pages/UsersPage.tsx
@@ -94,7 +94,13 @@ export function UsersPage() {
   }
 
   async function deleteUser(id: string, name: string) {
-    if (!confirm(`Delete user ${name}?`)) return;
+    if (
+      !confirm(
+        `Permanently delete user ${name}?\n\nThis removes their permissions, access requests, session history, and credentials.\n\nAudit entries they produced are kept (with the user field cleared). There is no archive for users — cancel if you are unsure.`,
+      )
+    ) {
+      return;
+    }
     try {
       await api(`/admin/users/${encodeURIComponent(id)}`, { method: "DELETE" });
       toast("User deleted");


### PR DESCRIPTION
## Summary
- Hard-deleting an agent no longer fails with `sessions_machine_id_fkey` after recordings exist; dependent permissions, access requests, and sessions are removed (plus synthetic `agent_id` user and on-disk casts when possible).
- Hard-deleting a user clears subject rows and nulls attribution FKs (`granted_by`, `reviewed_by`, audit, cert revoker) so history for others survives.
- `Migrate`/`repairSchema` inspects FK delete rules and repairs only when drifted; CLI `agent`/`user`/`permission`/`setup` open the DB through the same path.
- Agents/Users UI confirms that delete removes related records (archive agents to keep history).

## Test plan
- [x] Register agent → web terminal session → end → revoke → delete succeeds
- [x] Restart gateway on a pre-1.2 DB and confirm migrate repairs FKs without error; second restart is a no-op
- [x] `orion-belt-server agent delete <name>` on an old DB (before gateway restart) succeeds via CLI migrate/repair
- [x] Delete a non-last user who has sessions/permissions; audit rows remain with cleared `user_id`
- [x] Confirm copy on Agents delete mentions archive; Users delete warns about related records

## Out of scope (known follow-ups)
- Revoke/pause undone on agent reconnect
- Public `/register/client` `is_admin`
- OpenFGA drift / last-admin guard / archive name UNIQUE / retention `.enc`+DB rows